### PR TITLE
Status list

### DIFF
--- a/ArgentiRotations/Ranged/ChurinBRD.cs
+++ b/ArgentiRotations/Ranged/ChurinBRD.cs
@@ -302,7 +302,7 @@ public sealed class ChurinBRD : BardRotation
         #region GCD Skills
         private bool TryUseIronJaws(out IAction? act)
         {
-            if (!CurrentTarget?.HasStatus(true, StatusID.VenomousBite, StatusID.CausticBite, StatusID.Windbite, StatusID.Stormbite) == true)
+            if (CurrentTarget != null && !CurrentTarget.HasStatus(true, StatusID.VenomousBite, StatusID.CausticBite, StatusID.Windbite, StatusID.Stormbite))
             {
                 return SetActToNull(out act);
             }


### PR DESCRIPTION
This pull request makes adjustments to the `ChurinBRD` rotation logic in the `ArgentiRotations/Ranged` directory. The changes focus on improving default configuration values and refining conditional checks in the Bard's rotation logic.

### Configuration improvements:

* Set the default value of `CustomEnableFirstPotion` to `true` to ensure that the first potion is enabled by default for custom potion timings. (`ArgentiRotations/Ranged/ChurinBRD.cs`, [ArgentiRotations/Ranged/ChurinBRD.csR195-R197](diffhunk://#diff-8f2ae9a1e5673a6435081975b2cc9e6e769dc4e1d159ec57b8eee9c4bd70bdb9R195-R197))

### Logic refinement:

* Updated the conditional check in the `TryUseIronJaws` method to simplify and clarify the null-check logic for `CurrentTarget` and its status effects. (`ArgentiRotations/Ranged/ChurinBRD.cs`, [ArgentiRotations/Ranged/ChurinBRD.csL305-R306](diffhunk://#diff-8f2ae9a1e5673a6435081975b2cc9e6e769dc4e1d159ec57b8eee9c4bd70bdb9L305-R306))