### PR TITLE
yet another StatusList fix attempt

### DIFF
--- a/ArgentiRotations/Ranged/ChurinBRD.cs
+++ b/ArgentiRotations/Ranged/ChurinBRD.cs
@@ -303,7 +303,7 @@ public sealed class ChurinBRD : BardRotation
         #region GCD Skills
         private bool TryUseIronJaws(out IAction? act)
         {
-            if (CurrentTarget != null && !CurrentTarget.HasStatus(true, StatusID.VenomousBite, StatusID.CausticBite, StatusID.Windbite, StatusID.Stormbite))
+            if (CurrentTarget != null && !CurrentTarget.HasStatus(true, StatusID.VenomousBite, StatusID.CausticBite, StatusID.Windbite, StatusID.Stormbite) ||  CurrentTarget?.StatusList == null)
             {
                 return SetActToNull(out act);
             }


### PR DESCRIPTION
This pull request includes a small adjustment to the `GeneralGCD` method in `ArgentiRotations/Ranged/ChurinBRD.cs`. The change ensures that the `TryUseIronJaws` method will return `SetActToNull` if the `StatusList` of `CurrentTarget` is null, improving the handling of edge cases.