### PR TITLE
Remove ECommons project reference and related using directive

### DIFF
--- a/ArgentiRotations/ArgentiRotations.csproj
+++ b/ArgentiRotations/ArgentiRotations.csproj
@@ -29,10 +29,6 @@
             <Using Include="RotationSolver.Basic.Rotations.Basic"/>
             <Using Include="System.Numerics"/>
             <Using Include="System.Reflection"/>
-            <Using Include="ECommons.ExcelServices" />
-          </ItemGroup>
-          <ItemGroup>
-            <ProjectReference Include="..\ECommons\ECommons\ECommons.csproj" />
           </ItemGroup>
           <ItemGroup>
             <Folder Include="ArgentiRotations\Common"/>


### PR DESCRIPTION
This pull request removes unused dependencies and project references from the `ArgentiRotations.csproj` file to simplify the project configuration.

Dependency cleanup:

* [`ArgentiRotations/ArgentiRotations.csproj`](diffhunk://#diff-062dfb040a9df5e3450dc39b26a9b4647bc798bbc6f15ca2f810514baf51bab7L32-L35): Removed the `ECommons.ExcelServices` dependency and the project reference to `ECommons.csproj`, as they are no longer needed.