### PR TITLE
Sandbag!

### DIFF
--- a/ArgentiRotations/Ranged/Bard/BardStatusWindow.cs
+++ b/ArgentiRotations/Ranged/Bard/BardStatusWindow.cs
@@ -243,6 +243,57 @@ public sealed partial class ChurinBRD
                 }
                 ImGui.EndTable();
             }
+
+            // Additional tracked statuses
+            if (ImGui.TreeNode("Tracked Statuses"))
+            {
+                ImGui.Columns(2, "TrackedStatusesColumns", false);
+                ImGui.Text("Status");
+                ImGui.NextColumn();
+                ImGui.Text("Value");
+                ImGui.NextColumn();
+                ImGui.Separator();
+
+                ImGui.Text("Has Raging Strikes");
+                ImGui.NextColumn();
+                ImGui.Text(HasRagingStrikes.ToString());
+                ImGui.NextColumn();
+
+                ImGui.Text("Has Battle Voice");
+                ImGui.NextColumn();
+                ImGui.Text(HasBattleVoice.ToString());
+                ImGui.NextColumn();
+
+                ImGui.Text("Has Radiant Finale");
+                ImGui.NextColumn();
+                ImGui.Text(HasRadiantFinale.ToString());
+                ImGui.NextColumn();
+
+                ImGui.Text("In Wanderer's Minuet");
+                ImGui.NextColumn();
+                ImGui.Text(InWanderers.ToString());
+                ImGui.NextColumn();
+
+                ImGui.Text("In Mage's Ballad");
+                ImGui.NextColumn();
+                ImGui.Text(InMages.ToString());
+                ImGui.NextColumn();
+
+                ImGui.Text("In Army's Paeon");
+                ImGui.NextColumn();
+                ImGui.Text(InArmys.ToString());
+                ImGui.NextColumn();
+
+                ImGui.Text("Has Barrage");
+                ImGui.NextColumn();
+                ImGui.Text(HasBarrage.ToString());
+                ImGui.NextColumn();
+
+                ImGui.NextColumn();
+
+                ImGui.Columns(1);
+                ImGui.TreePop();
+            }
         }
         catch (Exception ex)
         {

--- a/ArgentiRotations/Ranged/Dancer/DancerStatusWindow.cs
+++ b/ArgentiRotations/Ranged/Dancer/DancerStatusWindow.cs
@@ -234,13 +234,12 @@ public sealed partial class ChurinDNC
     {
         try
         {
-            if (ImGui.BeginTable("PotionStatusTable", 6, ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg))
+            if (ImGui.BeginTable("PotionStatusTable", 4, ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg))
             {
                 ImGui.TableSetupColumn("Potion");
                 ImGui.TableSetupColumn("Enabled");
                 ImGui.TableSetupColumn("Used");
-                ImGui.TableSetupColumn("Can Use");
-                ImGui.TableSetupColumn("Condition");
+                ImGui.TableSetupColumn("Time");
                 ImGui.TableHeadersRow();
 
                 var trueColor = ImGuiColors.HealerGreen;
@@ -249,33 +248,81 @@ public sealed partial class ChurinDNC
                 for (var i = 0; i < _potions.Count; i++)
                 {
                     var (time, enabled, used) = _potions[i];
-                    var potionTimeInSeconds = time * 60;
-                    var isOpenerPotion = potionTimeInSeconds == 0;
-                    var isEvenMinutePotion = time % 2 == 0;
-
-                    var canUse = (isOpenerPotion && Countdown.TimeRemaining <= 1.5f) ||
-                                 (!isOpenerPotion && CombatTime >= potionTimeInSeconds &&
-                                  CombatTime < potionTimeInSeconds + 10);
-
-                    var condition = (isEvenMinutePotion ? InTwoMinuteWindow : InOddMinuteWindow) || isOpenerPotion;
-
                     ImGui.TableNextRow();
                     ImGui.TableSetColumnIndex(0);
                     ImGui.Text($"Potion {i + 1}");
-
                     ImGui.TableSetColumnIndex(1);
                     ImGui.TextColored(GetColor(enabled, trueColor, falseColor), enabled.ToString());
-
                     ImGui.TableSetColumnIndex(2);
                     ImGui.TextColored(GetColor(used, trueColor, falseColor), used.ToString());
-
                     ImGui.TableSetColumnIndex(3);
-                    ImGui.TextColored(GetColor(canUse, trueColor, falseColor), canUse.ToString());
-
-                    ImGui.TableSetColumnIndex(4);
-                    ImGui.TextColored(GetColor(condition, trueColor, falseColor), condition.ToString());
+                    ImGui.Text($"{time} min");
                 }
                 ImGui.EndTable();
+            }
+
+            // Additional tracked statuses
+            if (ImGui.TreeNode("Tracked Statuses"))
+            {
+                ImGui.Columns(2, "TrackedStatusesColumns", false);
+                ImGui.Text("Status");
+                ImGui.NextColumn();
+                ImGui.Text("Value");
+                ImGui.NextColumn();
+                ImGui.Separator();
+
+                ImGui.Text("Has Technical Step");
+                ImGui.NextColumn();
+                ImGui.Text(HasTechnicalStep.ToString());
+                ImGui.NextColumn();
+
+                ImGui.Text("Has Standard Step");
+                ImGui.NextColumn();
+                ImGui.Text(HasStandardStep.ToString());
+                ImGui.NextColumn();
+
+                ImGui.Text("Has Devilment");
+                ImGui.NextColumn();
+                ImGui.Text(HasDevilment.ToString());
+                ImGui.NextColumn();
+
+                ImGui.Text("Has Medicated");
+                ImGui.NextColumn();
+                ImGui.Text(IsMedicated.ToString());
+                ImGui.NextColumn();
+
+                ImGui.Text("Has Tillana");
+                ImGui.NextColumn();
+                ImGui.Text(HasTillana.ToString());
+                ImGui.NextColumn();
+
+                ImGui.Text("Has Last Dance");
+                ImGui.NextColumn();
+                ImGui.Text(HasLastDance.ToString());
+                ImGui.NextColumn();
+
+                ImGui.Text("Has Any Proc");
+                ImGui.NextColumn();
+                ImGui.Text(HasAnyProc.ToString());
+                ImGui.NextColumn();
+
+                ImGui.Text("Is Dancing");
+                ImGui.NextColumn();
+                ImGui.Text(IsDancing.ToString());
+                ImGui.NextColumn();
+
+                ImGui.Text("Is Burst Phase");
+                ImGui.NextColumn();
+                ImGui.Text(IsBurstPhase.ToString());
+                ImGui.NextColumn();
+
+                ImGui.Text("Flourish Cooldown");
+                ImGui.NextColumn();
+                ImGui.Text($"{FlourishPvE.Cooldown.RecastTimeElapsed:F1} / {FlourishCooldown}s");
+                ImGui.NextColumn();
+
+                ImGui.Columns(1);
+                ImGui.TreePop();
             }
         }
         catch (Exception ex)

--- a/ArgentiRotations/packages.lock.json
+++ b/ArgentiRotations/packages.lock.json
@@ -17,7 +17,7 @@
       "RotationSolverReborn.Basic": {
         "type": "Direct",
         "requested": "[*-*, )",
-        "resolved": "7.2.5.67",
+        "resolved": "7.2.5.72",
         "contentHash": "81wVkK1zSU0oWjQogrHQBslAg7lFBvpS12DEh1tf+ZGGHZLB0KSnx1cHL2lB3GnoLXHO4JDivddg9NDPb0JU1Q==",
         "dependencies": {
           "Svg": "3.4.7",


### PR DESCRIPTION
This pull request introduces several changes to the Bard rotation logic in the `ArgentiRotations` project, focusing on enhancing status tracking, refining potion logic, and adding a new "Sandbag Mode" feature. These updates aim to improve the flexibility and performance of Bard rotations in PvE scenarios.

### Status Tracking Enhancements:
* Added a new section in `BardStatusWindow.cs` to display tracked statuses, such as `Has Raging Strikes`, `Has Battle Voice`, and song-specific statuses like `In Wanderer's Minuet`. This provides better visibility into the Bard's active buffs and statuses during gameplay.

### Potion Logic Updates:
* Introduced `EvenMinutePots` and `OddMinutePots` logic in `ChurinBRD.cs` to optimize potion usage based on cycle timing, active buffs, and Soul Voice levels.

### Sandbag Mode Implementation:
* Added a new configuration option `EnableSandbagMode` in `ChurinBRD.cs`. This mode adjusts ability usage logic to prioritize sustained DPS over burst damage in specific scenarios, such as prolonged fights. [[1]](diffhunk://#diff-0fc5965f7f92a6b8a387c374bb3934e61406724893c3134bb81f8205cf0f4ba8R177-R178) [[2]](diffhunk://#diff-0fc5965f7f92a6b8a387c374bb3934e61406724893c3134bb81f8205cf0f4ba8L472-R554)

### Ability Logic Refinements:
* Refactored ability usage methods (`TryUseDoTs`, `TryUseIronJaws`, `TryUseBlastArrow`, etc.) to incorporate conditions for "Sandbag Mode" and improve decision-making based on combat status and cooldown timings. [[1]](diffhunk://#diff-0fc5965f7f92a6b8a387c374bb3934e61406724893c3134bb81f8205cf0f4ba8L255-R314) [[2]](diffhunk://#diff-0fc5965f7f92a6b8a387c374bb3934e61406724893c3134bb81f8205cf0f4ba8L413-R481) [[3]](diffhunk://#diff-0fc5965f7f92a6b8a387c374bb3934e61406724893c3134bb81f8205cf0f4ba8L545-R574)

### Miscellaneous Updates:
* Updated the description of the Bard rotation in `ChurinBRD.cs` to reflect thematic changes.