### PR TITLE
API Bump

### DIFF
--- a/ArgentiRotations/ArgentiRotations.csproj
+++ b/ArgentiRotations/ArgentiRotations.csproj
@@ -10,7 +10,7 @@
           </PropertyGroup>
   
           <ItemGroup>
-            <PackageReference Include="RotationSolverReborn.Basic" Version="*-*"/>
+            <PackageReference Include="RotationSolverReborn.Basic" Version="7.2.5.87" />
           </ItemGroup>
   
           <ItemGroup>

--- a/ArgentiRotations/Ranged/Bard/ChurinBRD.cs
+++ b/ArgentiRotations/Ranged/Bard/ChurinBRD.cs
@@ -6,7 +6,7 @@ namespace ArgentiRotations.Ranged;
 [Rotation("Churin BRD", CombatType.PvE, GameVersion = "7.2.5",
     Description = "I sing the body electric. I gasp the body organic. I miss the body remembered.")]
 [SourceCode(Path = "ArgentiRotations/Ranged/Bard/ChurinBRD.cs")]
-[Api(4)]
+[Api(5)]
 public sealed partial class ChurinBRD : BardRotation
 {
     #region Properties
@@ -279,21 +279,14 @@ public sealed partial class ChurinBRD : BardRotation
 
     private bool TryUseIronJaws(out IAction? act)
     {
-        if (CurrentTarget != null && InCombat && CurrentTarget.StatusList != null && !CurrentTarget.HasStatus(true,
-                StatusID.VenomousBite, StatusID.CausticBite, StatusID.Windbite, StatusID.Stormbite))
-            return SetActToNull(out act);
-
-        // Ensure IronJawsPvE.Target.Target and its StatusList are not null before accessing
-        var ironJawsTarget = CurrentTarget != null && IronJawsPvE.Target.Target != null;
-        if (ironJawsTarget && IronJawsPvE.Target.Target?.StatusList != null &&
-            IronJawsPvE.Target.Target.WillStatusEnd(30, true, IronJawsPvE.Setting.TargetStatusProvide ?? []))
-            if (InBurst &&
-                Player.WillStatusEndGCD(1, 1, true, StatusID.BattleVoice, StatusID.RadiantFinale,
-                    StatusID.RagingStrikes) &&
-                !BlastArrowPvE.CanUse(out _))
-                return IronJawsPvE.CanUse(out act, skipStatusProvideCheck: true, skipAoeCheck: true);
-
-        return IronJawsPvE.CanUse(out act) || SetActToNull(out act);
+        if (IronJawsPvE.CanUse(out act, skipStatusProvideCheck: true) && (IronJawsPvE.Target.Target?.WillStatusEnd(30, true, IronJawsPvE.Setting.TargetStatusProvide ?? []) ?? false))
+        {
+            if (InBurst && Player.WillStatusEndGCD(1, 1, true, StatusID.BattleVoice, StatusID.RadiantFinale, StatusID.RagingStrikes) && !BlastArrowPvE.CanUse(out _))
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     private bool TryUseDoTs(out IAction? act)


### PR DESCRIPTION
This pull request includes updates to the `ArgentiRotations` project, focusing on dependency version updates, API adjustments, and refinements to rotation logic for Bard and Dancer classes. The changes aim to improve compatibility, optimize combat logic, and enhance potion handling.

### Dependency Updates:
* Updated the `RotationSolverReborn.Basic` package reference in `ArgentiRotations/ArgentiRotations.csproj` to version `7.2.5.87`, ensuring compatibility with the latest features and fixes.

### API Adjustments:
* Changed the `Api` version for `ChurinBRD` in `ArgentiRotations/Ranged/Bard/ChurinBRD.cs` and `ChurinDNC` in `ArgentiRotations/Ranged/Dancer/ChurinDNC.cs` from `4` to `5`, aligning with the updated API requirements. [[1]](diffhunk://#diff-0fc5965f7f92a6b8a387c374bb3934e61406724893c3134bb81f8205cf0f4ba8L9-R9) [[2]](diffhunk://#diff-dc95a0b08dddbd9d2675a3a5c9cccdcf181579ae5f35b14a06de1aa1b7767c5dL7-R7)

### Bard Rotation Logic Improvements:
* Simplified and optimized the `TryUseIronJaws` method in `ChurinBRD` to reduce redundant checks and improve performance during combat scenarios.

### Dancer Rotation Logic Refinements:
* Adjusted potion handling logic in `ChurinDNC`:
  - Modified `CountDownAction` to initialize potions instead of resetting them.
  - Enhanced `TryUsePotion` to allow a slightly larger window for opener potions and refined conditions for potion usage during combat.
  - Commented out the `ResetPotions` functionality in `UpdatePotions` to prevent unintended resets during combat.
* Updated the `TryUseFlourish` method to optimize cooldown checks and improve decision-making during burst phases.