### PR TITLE
Mini DNC and BRD update

### DIFF
--- a/ArgentiRotations/ArgentiRotations.csproj
+++ b/ArgentiRotations/ArgentiRotations.csproj
@@ -34,6 +34,7 @@
             <Folder Include="ArgentiRotations\Common"/>
             <Folder Include="ArgentiRotations\Ranged"/>
             <Folder Include="ArgentiRotations\Encounter"/>
+            <Folder Include="Encounter.tmp\Savage.tmp\M6SSugarRiot\" />
           </ItemGroup>
           <ItemGroup>
             <None Update="ArgentiRotations.json">

--- a/ArgentiRotations/ArgentiRotations.sln
+++ b/ArgentiRotations/ArgentiRotations.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArgentiRotations", "ArgentiRotations.csproj", "{E3FB7CA6-EA05-81B2-E914-6D180D08321D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E3FB7CA6-EA05-81B2-E914-6D180D08321D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E3FB7CA6-EA05-81B2-E914-6D180D08321D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E3FB7CA6-EA05-81B2-E914-6D180D08321D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E3FB7CA6-EA05-81B2-E914-6D180D08321D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D7E78F59-4BE5-41D7-ACB7-8AF8F9AFB645}
+	EndGlobalSection
+EndGlobal

--- a/ArgentiRotations/Common/PartyComposition.cs
+++ b/ArgentiRotations/Common/PartyComposition.cs
@@ -1,0 +1,118 @@
+﻿using Dalamud.Game.ClientState.Objects.SubKinds;
+using ECommons.DalamudServices;
+
+namespace ArgentiRotations.Common;
+
+public class PartyComposition
+{
+    private static ulong _hostileTargetId = 0;
+    private static IPlayerCharacter Player => ECommons.GameHelpers.Player.Object;
+
+    private static IBattleChara? HostileTarget
+    {
+        get => Svc.Objects.SearchById(_hostileTargetId) as IBattleChara;
+        set => _hostileTargetId = value?.GameObjectId ?? 0UL;
+    }
+
+    public static bool HasBuffs
+    {
+        get
+        {
+            StatusList();
+
+            if (Buffs.Count == 0) return false;
+
+            // Check if player has any buff from our list, and it's not about to expire
+            var playerHasBuffs = Buffs.Where(buff => buff.Type == StatusType.Buff)
+                .Any(buff => Player.HasStatus(false, buff.Ids) &&
+                             !Player.WillStatusEnd(0, false, buff.Ids));
+
+            // Check if target has any debuff from our list, and it's not about to expire
+            var targetHasDebuffs = HostileTarget != null &&
+                                   Buffs.Where(buff => buff.Type == StatusType.Debuff)
+                                       .Any(buff => HostileTarget.HasStatus(false, buff.Ids) &&
+                                                    !HostileTarget.WillStatusEnd(0, false, buff.Ids));
+            return playerHasBuffs || targetHasDebuffs;
+        }
+    }
+
+    public static List<StatusInfo> Buffs { get; } = [];
+
+    public static void StatusList()
+    {
+        Buffs.Clear();
+        var processedJobs = new HashSet<string>();
+
+        if (CustomRotation.PartyComposition == null)
+        {
+            var abbr = Player.ClassJob.Value.Abbreviation.ToString();
+            AddJobBuffs(abbr, processedJobs);
+        }
+        else
+        {
+            foreach (var job in CustomRotation.PartyComposition)
+            {
+                var abbr = job.Value.Abbreviation.ToString();
+                AddJobBuffs(abbr, processedJobs);
+            }
+        }
+    }
+
+    private static readonly Dictionary<string, List<StatusInfo>> JobBuffs = new()
+    {
+        { "AST", [new StatusInfo("Divination", "AST", StatusType.Buff, StatusID.Divination)] },
+        { "BRD", [
+                new StatusInfo("Battle Voice", "BRD", StatusType.Buff, StatusID.BattleVoice),
+                new StatusInfo("Radiant Finale", "BRD", StatusType.Buff, StatusID.RadiantFinale_2964,
+                    StatusID.RadiantFinale)]
+        },
+        { "DNC", [new StatusInfo("Technical Finish", "DNC", StatusType.Buff, StatusID.TechnicalFinish)] },
+        { "DRG", [new StatusInfo("Battle Litany", "DRG", StatusType.Buff, StatusID.BattleLitany)] },
+        { "MNK", [new StatusInfo("Brotherhood", "MNK", StatusType.Buff, StatusID.Brotherhood)] },
+        {
+            "NIN", [
+                new StatusInfo("Mug", "NIN", StatusType.Debuff, StatusID.Mug),
+                new StatusInfo("Dokumori", "NIN", StatusType.Debuff, StatusID.Dokumori, StatusID.Dokumori_4303)
+            ]
+        },
+        { "PCT", [new StatusInfo("Starry Muse", "PCT", StatusType.Buff, StatusID.StarryMuse)] },
+        { "RPR", [new StatusInfo("Arcane Circle", "RPR", StatusType.Buff, StatusID.ArcaneCircle)] },
+        {
+            "RDM", [new StatusInfo("Embolden", "RDM", StatusType.Buff, StatusID.Embolden, StatusID.Embolden_1297)]
+        },
+        {
+            "SCH",
+            [
+                new StatusInfo("Chain Stratagem", "SCH", StatusType.Debuff, StatusID.ChainStratagem,
+                    StatusID.ChainStratagem_1406)
+            ]
+        },
+        { "SMN", [new StatusInfo("Searing Light", "SMN", StatusType.Buff, StatusID.SearingLight)] }
+    };
+
+    private static void AddJobBuffs(string abbr, HashSet<string> processedJobs)
+    {
+        if (!processedJobs.Add(abbr)) return;
+
+        if (JobBuffs.TryGetValue(abbr, out var buffs))
+        {
+            Buffs.AddRange(buffs);
+        }
+    }
+}
+
+
+
+public enum StatusType
+{
+    Buff,
+    Debuff
+}
+
+public class StatusInfo(string name, string jobAbbr,StatusType type, params StatusID[] ids)
+{
+    public StatusID[] Ids { get; } = ids;
+    public string Name { get; } = name;
+    public string JobAbbr { get; } = jobAbbr;
+    public StatusType Type { get; } = type;
+}

--- a/ArgentiRotations/Ranged/Bard/BardStatusWindow.cs
+++ b/ArgentiRotations/Ranged/Bard/BardStatusWindow.cs
@@ -16,9 +16,7 @@ public sealed partial class ChurinBRD
     private Vector4[] _timingConditions = [];
     
 #endregion
-    
     #region Status Window Override
-    
     public override void DisplayStatus()
     {
         try
@@ -26,6 +24,7 @@ public sealed partial class ChurinBRD
             DisplayStatusHelper.BeginPaddedChild("ChurinBRD Status", true,
                 ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoScrollbar);
             DrawRotationStatus();
+            DrawPartyCompositionHeader();
             DrawCombatStatusHeader();
             DrawSongTimingHeader();
             DrawPotionStatusHeader();
@@ -36,7 +35,6 @@ public sealed partial class ChurinBRD
             ImGui.TextColored(ImGuiColors.DalamudRed, $"Error displaying status: {ex.Message}");
         }
     }
-
     private void DrawRotationStatus()
     {
         var text = "Rotation: " + Name;
@@ -46,57 +44,99 @@ public sealed partial class ChurinBRD
             ImGui.TextColored(ImGuiColors.HealerGreen, text);
             DisplayStatusHelper.HoveredTooltip(Description);
         }, ImGui.GetWindowWidth(), textSize);
-    }    private void DrawCombatStatusHeader()
-    {
-        try
-        {
-            InitializeColorData();
-            ImGui.BeginGroup();
-            if (ImGui.CollapsingHeader("Combat Status Details", ImGuiTreeNodeFlags.DefaultOpen))
-            {
-                DrawCombatStatusText();
-            }
-            ImGui.EndGroup();
-        }
-        catch (Exception)
-        {
-            ImGui.TextColored(ImGuiColors.DalamudRed, "Error displaying combat status");
-        }
     }
 
-    private void DrawSongTimingHeader()
+    #region Party Composition
+    private static void DrawPartyCompositionHeader()
     {
         try
         {
             ImGui.BeginGroup();
-            if (ImGui.CollapsingHeader("Song Timing Information", ImGuiTreeNodeFlags.DefaultOpen))
+            if (ImGui.CollapsingHeader("Party Composition", ImGuiTreeNodeFlags.DefaultOpen))
             {
-                DrawSongTimingDetails();
+                DrawPartyCompositionText();
             }
             ImGui.EndGroup();
         }
         catch (Exception)
         {
-            ImGui.TextColored(ImGuiColors.DalamudRed, "Error displaying song timing");
+            ImGui.TextColored(ImGuiColors.DalamudRed, "Error displaying party composition");
         }
     }
-
-    private void DrawPotionStatusHeader()
+    private static void DrawPartyCompositionText()
     {
-        try
+        ArgentiRotations.Common.PartyComposition.StatusList();
+        if (ImGui.BeginTable("PartyCompositionTable", 3, ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg))
         {
-            ImGui.BeginGroup();
-            if (ImGui.CollapsingHeader("Potion Status", ImGuiTreeNodeFlags.DefaultOpen))
+            ImGui.TableSetupColumn("Role");
+            ImGui.TableSetupColumn("Job");
+            ImGui.TableSetupColumn("Buffs Provided");
+            ImGui.TableHeadersRow();
+
+            if (PartyComposition.Count == 0)
             {
-                DrawPotionStatusText();
+                ImGui.TableNextRow();
+                ImGui.TableSetColumnIndex(0);
+                ImGui.Text(Player.ClassJob.Value.GetJobRole().ToString());
+
+                ImGui.TableSetColumnIndex(1);
+                var jobAbbr = Player.ClassJob.Value.Abbreviation.ToString();
+                ImGui.Text(jobAbbr);
+
+                ImGui.TableSetColumnIndex(2);
+                var buffs = ArgentiRotations.Common.PartyComposition.Buffs
+                    .Where(b => b.JobAbbr == jobAbbr)
+                    .Select(b => $"{b.Name} ({b.Type}")
+                    .ToList();
+
+                var buffText = buffs.Count != 0 ? string.Join(", ", buffs) : "None";
+                ImGui.Text(buffText);
             }
-            ImGui.EndGroup();
+
+            foreach (var member in PartyComposition)
+            {
+                ImGui.TableNextRow();
+
+                ImGui.TableSetColumnIndex(0);
+                ImGui.Text(member.Value.GetJobRole().ToString());
+
+                ImGui.TableSetColumnIndex(1);
+                var jobAbbr = member.Value.Abbreviation.ToString();
+                ImGui.Text(jobAbbr);
+
+                ImGui.TableSetColumnIndex(2);
+                var buffs = ArgentiRotations.Common.PartyComposition.Buffs
+                    .Where(b => b.JobAbbr == jobAbbr)
+                    .Select(b => b.Name)
+                    .ToList();
+
+                var buffText = buffs.Count != 0 ? string.Join(", ", buffs) : "None";
+                ImGui.Text(buffText);
+            }
         }
-        catch (Exception)
+        ImGui.EndTable();
+    }
+
+    #endregion
+    #region Combat Status
+    private void DrawCombatStatusHeader()
         {
-            ImGui.TextColored(ImGuiColors.DalamudRed, "Error displaying potion status");
+            try
+            {
+                InitializeColorData();
+                ImGui.BeginGroup();
+                if (ImGui.CollapsingHeader("Combat Status Details", ImGuiTreeNodeFlags.DefaultOpen))
+                {
+                    DrawCombatStatusText();
+                }
+                ImGui.EndGroup();
+            }
+            catch (Exception)
+            {
+                ImGui.TextColored(ImGuiColors.DalamudRed, "Error displaying combat status");
+            }
         }
-    }    private void DrawCombatStatusText()
+    private void DrawCombatStatusText()
     {
         try
         {
@@ -141,7 +181,7 @@ public sealed partial class ChurinBRD
                 ImGui.Columns(1);
                 ImGui.TreePop();
             }
-            
+
             if (ImGui.TreeNode("Status Booleans"))
             {
                 ImGui.Columns(2, "StatusColumns", false);
@@ -191,24 +231,108 @@ public sealed partial class ChurinBRD
             ImGui.TextColored(ImGuiColors.DalamudRed, "Error displaying combat status");
         }
     }
-
-    private void DrawSongTimingDetails()
-    {
-        if (ImGui.BeginTable("SongTimingTable", 2, ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg))
+    #endregion
+    #region Songs
+    private void DrawSongTimingHeader()
         {
-            ImGui.TableSetupColumn("Label");
-            ImGui.TableSetupColumn("Value");
-            ImGui.TableHeadersRow();
+            try
+            {
+                ImGui.BeginGroup();
+                if (ImGui.CollapsingHeader("Song Timing Information", ImGuiTreeNodeFlags.DefaultOpen))
+                {
+                    DrawSongTimingDetails();
+                }
+                ImGui.EndGroup();
+            }
+            catch (Exception)
+            {
+                ImGui.TextColored(ImGuiColors.DalamudRed, "Error displaying song timing");
+            }
+        }
+    private void DrawSongTimingDetails()
+        {
+            if (ImGui.BeginTable("SongTimingTable", 2, ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg))
+            {
+                ImGui.TableSetupColumn("Label");
+                ImGui.TableSetupColumn("Value");
+                ImGui.TableHeadersRow();
 
-            DrawSongTimingInfo();
-            DrawCurrentSongInfo();
-            DrawSongUptimeInfo();
-            DrawTimingInfo();
+                DrawSongTimingInfo();
+                DrawCurrentSongInfo();
+                DrawSongUptimeInfo();
+                DrawCycleInfo();
 
-            ImGui.EndTable();
+                ImGui.EndTable();
+            }
+        }
+    private void DrawSongTimingInfo()
+        {
+            ImGui.TableNextRow();
+            ImGui.TableNextColumn();
+            ImGui.Text("Current Song Timing Preset");
+            ImGui.TableNextColumn();
+            ImGui.Text(SongTimings.ToString());
+        }
+    private static void DrawCurrentSongInfo()
+    {
+        ImGui.TableNextRow();
+        ImGui.TableNextColumn();
+        ImGui.Text("Current Song");
+        ImGui.TableNextColumn();
+        ImGui.Text(Song.ToString());
+    }
+    private void DrawSongUptimeInfo()
+        {
+            // Wanderer's Minuet
+            ImGui.TableNextRow();
+            ImGui.TableNextColumn();
+            ImGui.Text("Wanderer's Minuet Uptime & Remaining Time");
+            ImGui.TableNextColumn();
+            ImGui.Text($"Preset Time: {WandTime} seconds");
+            ImGui.Text($"Remaining Time: {WandRemainTime} seconds");
+
+            // Mage's Ballad
+            ImGui.TableNextRow();
+            ImGui.TableNextColumn();
+            ImGui.Text("Mage's Ballad Uptime & Remaining Time");
+            ImGui.TableNextColumn();
+            ImGui.Text($"Preset Time: {MageTime} seconds");
+            ImGui.Text($"Remaining Time: {MageRemainTime} seconds");
+
+            // Army's Paeon
+            ImGui.TableNextRow();
+            ImGui.TableNextColumn();
+            ImGui.Text("Army's Paeon Uptime & Remaining Time");
+            ImGui.TableNextColumn();
+            ImGui.Text($"Preset Time: {ArmyTime} seconds");
+            ImGui.Text($"Remaining Time: {ArmyRemainTime} seconds");
+        }
+    private static void DrawCycleInfo()
+        {
+            ImGui.TableNextRow();
+            ImGui.TableNextColumn();
+            ImGui.Text("Is First Cycle?");
+            ImGui.TableNextColumn();
+            ImGui.Text(IsFirstCycle ? "Yes" : "No");
+        }
+    #endregion
+    #region Potions
+    private void DrawPotionStatusHeader()
+    {
+        try
+        {
+            ImGui.BeginGroup();
+            if (ImGui.CollapsingHeader("Potion Status", ImGuiTreeNodeFlags.DefaultOpen))
+            {
+                DrawPotionStatusText();
+            }
+            ImGui.EndGroup();
+        }
+        catch (Exception)
+        {
+            ImGui.TextColored(ImGuiColors.DalamudRed, "Error displaying potion status");
         }
     }
-
     private void DrawPotionStatusText()
     {
         try
@@ -244,56 +368,6 @@ public sealed partial class ChurinBRD
                 ImGui.EndTable();
             }
 
-            // Additional tracked statuses
-            if (ImGui.TreeNode("Tracked Statuses"))
-            {
-                ImGui.Columns(2, "TrackedStatusesColumns", false);
-                ImGui.Text("Status");
-                ImGui.NextColumn();
-                ImGui.Text("Value");
-                ImGui.NextColumn();
-                ImGui.Separator();
-
-                ImGui.Text("Has Raging Strikes");
-                ImGui.NextColumn();
-                ImGui.Text(HasRagingStrikes.ToString());
-                ImGui.NextColumn();
-
-                ImGui.Text("Has Battle Voice");
-                ImGui.NextColumn();
-                ImGui.Text(HasBattleVoice.ToString());
-                ImGui.NextColumn();
-
-                ImGui.Text("Has Radiant Finale");
-                ImGui.NextColumn();
-                ImGui.Text(HasRadiantFinale.ToString());
-                ImGui.NextColumn();
-
-                ImGui.Text("In Wanderer's Minuet");
-                ImGui.NextColumn();
-                ImGui.Text(InWanderers.ToString());
-                ImGui.NextColumn();
-
-                ImGui.Text("In Mage's Ballad");
-                ImGui.NextColumn();
-                ImGui.Text(InMages.ToString());
-                ImGui.NextColumn();
-
-                ImGui.Text("In Army's Paeon");
-                ImGui.NextColumn();
-                ImGui.Text(InArmys.ToString());
-                ImGui.NextColumn();
-
-                ImGui.Text("Has Barrage");
-                ImGui.NextColumn();
-                ImGui.Text(HasBarrage.ToString());
-                ImGui.NextColumn();
-
-                ImGui.NextColumn();
-
-                ImGui.Columns(1);
-                ImGui.TreePop();
-            }
         }
         catch (Exception ex)
         {
@@ -301,117 +375,8 @@ public sealed partial class ChurinBRD
         }
     }
 
-    private void DrawSongTimingInfo()
-    {
-        ImGui.TableNextRow();
-        ImGui.TableNextColumn();
-        ImGui.Text("Current Song Timing Preset");
-        ImGui.TableNextColumn();
-        ImGui.Text(SongTimings.ToString());
-    }
-
-    private void DrawCurrentSongInfo()
-    {
-        ImGui.TableNextRow();
-        ImGui.TableNextColumn();
-        ImGui.Text("Current Song");
-        ImGui.TableNextColumn();
-        ImGui.Text(Song.ToString());
-    }
-
-    private void DrawSongUptimeInfo()
-    {
-        // Wanderer's Minuet
-        ImGui.TableNextRow();
-        ImGui.TableNextColumn();
-        ImGui.Text("Wanderer's Minuet Uptime & Remaining Time");
-        ImGui.TableNextColumn();
-        ImGui.Text($"Preset Time: {WandTime} seconds");
-        ImGui.Text($"Remaining Time: {WandRemainTime} seconds");
-
-        // Mage's Ballad
-        ImGui.TableNextRow();
-        ImGui.TableNextColumn();
-        ImGui.Text("Mage's Ballad Uptime & Remaining Time");
-        ImGui.TableNextColumn();
-        ImGui.Text($"Preset Time: {MageTime} seconds");
-        ImGui.Text($"Remaining Time: {MageRemainTime} seconds");
-
-        // Army's Paeon
-        ImGui.TableNextRow();
-        ImGui.TableNextColumn();
-        ImGui.Text("Army's Paeon Uptime & Remaining Time");
-        ImGui.TableNextColumn();
-        ImGui.Text($"Preset Time: {ArmyTime} seconds");
-        ImGui.Text($"Remaining Time: {ArmyRemainTime} seconds");
-    }
-
-    private void DrawCycleInfo()
-    {
-        ImGui.TableNextRow();
-        ImGui.TableNextColumn();
-        ImGui.Text("Is First Cycle?");
-        ImGui.TableNextColumn();
-        ImGui.Text(IsFirstCycle ? "Yes" : "No");
-    }
-
-    private void DrawTargetInfo()
-    {
-        ImGui.TableNextRow();
-        ImGui.TableNextColumn();
-        ImGui.Text("Target Has DoTs?");
-        ImGui.TableNextColumn();
-        ImGui.Text(TargetHasDoTs ? "Yes" : "No");
-    }
-
-    private void DrawTimingInfo()
-    {
-        ImGui.TableNextRow();
-        ImGui.TableNextColumn();
-        ImGui.Text("Adjusted Recast Time");
-        ImGui.TableNextColumn();
-        ImGui.Text(RecastTime.ToString(CultureInfo.CurrentCulture));
-
-        ImGui.TableNextRow();
-        ImGui.TableNextColumn();
-        ImGui.Text("Time until the next GCD");
-        ImGui.TableNextColumn();
-        ImGui.Text(NextAbilityToNextGCD.ToString(CultureInfo.CurrentCulture));
-
-        ImGui.TableNextRow();
-        ImGui.TableNextColumn();
-        ImGui.Text("Recast Time remaining for Empyreal Arrow");
-        ImGui.TableNextColumn();
-        ImGui.Text(EmpyrealArrowPvE.Cooldown.RecastTimeRemainOneCharge.ToString(CultureInfo.CurrentCulture));
-    }
-
-    private void DrawWeaveInfo()
-    {
-        ImGui.TableNextRow();
-        ImGui.TableNextColumn();
-        ImGui.Text("Enough Weave Time");
-        ImGui.Text("Can Early Weave");
-        ImGui.Text("Can Late Weave");
-        ImGui.TableNextColumn();
-        ImGui.Text(EnoughWeaveTime ? "Yes " : "No ");
-        ImGui.Text(CanEarlyWeave ? "Yes " : "No ");
-        ImGui.Text(CanLateWeave ? "Yes " : "No ");
-    }
-
-    private void DrawPotionInfo()
-    {
-        ImGui.TableNextRow();
-        ImGui.TableNextColumn();
-        ImGui.Text("Potion Usage");
-        ImGui.TableNextColumn();
-        foreach (var (time, enabled, used) in _potions)
-        {
-            var status = used ? "Used" : "Pending";
-            ImGui.Text($"{time} min: {(enabled ? "Enabled" : "Disabled")} - {status}");
-        }    }
-
     #endregion
-    
+    #endregion
     #region Status Window Helper Methods
 
     private static Vector4 GetColor(bool condition, Vector4 trueColor, Vector4 falseColor)


### PR DESCRIPTION
This pull request introduces significant updates to the `ArgentiRotations` project, focusing on adding new functionality for party composition tracking, improving the Bard status window, and restructuring code for better readability and maintainability. The most notable changes include the addition of a `PartyComposition` class, enhancements to the Bard status display, and updates to potion and song timing logic.

### New functionality for party composition:

* Added a `PartyComposition` class in `ArgentiRotations/Common/PartyComposition.cs` to track buffs and debuffs provided by party members. This includes methods to identify statuses, associate them with jobs, and check their expiration. (`[ArgentiRotations/Common/PartyComposition.csR1-R118](diffhunk://#diff-0d6765e55999d9082424c355c9740a4e082b242959117805b5662f7d646fb441R1-R118)`)

### Enhancements to Bard status window:

* Updated `ArgentiRotations/Ranged/Bard/BardStatusWindow.cs` to include a new "Party Composition" section in the status window. This displays each party member's role, job, and buffs provided, using a table format. (`[[1]](diffhunk://#diff-61bb5900c5a164dd2f8366e1f7ffe05d6e06e334e7bd8fe323340e96adcd1605L19-R27)`, `[[2]](diffhunk://#diff-61bb5900c5a164dd2f8366e1f7ffe05d6e06e334e7bd8fe323340e96adcd1605L49-R139)`)
* Refactored the Bard status window code by grouping related methods into regions (e.g., "Party Composition," "Combat Status," "Potions") for better organization. (`[[1]](diffhunk://#diff-61bb5900c5a164dd2f8366e1f7ffe05d6e06e334e7bd8fe323340e96adcd1605L194-R251)`, `[[2]](diffhunk://#diff-61bb5900c5a164dd2f8366e1f7ffe05d6e06e334e7bd8fe323340e96adcd1605L348-R379)`)

### DNC logic cleanup
* Updated methods in the ChurinDNC to improve flow.


### Updates to potion and song timing logic:

* Simplified potion usage logic in `ArgentiRotations/Ranged/Bard/ChurinBRD.cs` by removing unused conditions and adding checks for new statuses like `IsMedicated` and `HasResonantArrow`. (`[[1]](diffhunk://#diff-0fc5965f7f92a6b8a387c374bb3934e61406724893c3134bb81f8205cf0f4ba8L106-R111)`, `[[2]](diffhunk://#diff-0fc5965f7f92a6b8a387c374bb3934e61406724893c3134bb81f8205cf0f4ba8R125-R127)`)