### PR TITLE
7.3 Update :D

### DIFF
--- a/ArgentiRotations/ArgentiRotations.csproj
+++ b/ArgentiRotations/ArgentiRotations.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Dalamud.NET.Sdk/12.0.2">
+<Project Sdk="Dalamud.NET.Sdk/13.0.0">
           <PropertyGroup>
             <TargetFramework>.net9.0-windows</TargetFramework>
             <AssemblyName>$(MSBuildProjectName)</AssemblyName>
@@ -10,14 +10,14 @@
           </PropertyGroup>
   
           <ItemGroup>
-            <PackageReference Include="RotationSolverReborn.Basic" Version="7.2.5.*-*" />
+            <PackageReference Include="RotationSolverReborn.Basic" Version= "*" />
+            <PackageReference Update="DalamudPackager" Version="13.0.0" />
           </ItemGroup>
   
           <ItemGroup>
             <Using Include="Dalamud.Game.ClientState.JobGauge.Enums"/>
             <Using Include="Dalamud.Game.ClientState.Objects.Types"/>
             <Using Include="Dalamud.Interface"/>
-            <Using Include="ImGuiNET"/>
             <Using Include="Newtonsoft.Json"/>
             <Using Include="RotationSolver.Basic"/>
             <Using Include="RotationSolver.Basic.Actions"/>
@@ -34,7 +34,6 @@
             <Folder Include="ArgentiRotations\Common"/>
             <Folder Include="ArgentiRotations\Ranged"/>
             <Folder Include="ArgentiRotations\Encounter"/>
-            <Folder Include="Encounter.tmp\Savage.tmp\M6SSugarRiot\" />
           </ItemGroup>
           <ItemGroup>
             <None Update="ArgentiRotations.json">

--- a/ArgentiRotations/Common/DisplayStatusHelper.cs
+++ b/ArgentiRotations/Common/DisplayStatusHelper.cs
@@ -1,4 +1,4 @@
-using System;
+using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
@@ -83,7 +83,7 @@ internal static class DisplayStatusHelper
     }
 
 
-    public static bool BeginPaddedChild(string strId, bool border = false, ImGuiWindowFlags flags = 0)
+    public static void BeginPaddedChild(string strId, bool border = false, ImGuiWindowFlags flags = 0)
     {
         var padding = ImGui.GetStyle().WindowPadding.X;
         // Set cursor position with padding
@@ -97,7 +97,7 @@ internal static class DisplayStatusHelper
         size.Y -= 2 * padding;
 
         // Begin the child window
-        return ImGui.BeginChild(strId, size, border, flags);
+        ImGui.BeginChild(strId, size, border, flags);
     }
 
     public static void EndPaddedChild()

--- a/ArgentiRotations/Common/PartyComposition.cs
+++ b/ArgentiRotations/Common/PartyComposition.cs
@@ -7,7 +7,6 @@ public class PartyComposition
 {
     private static ulong _hostileTargetId = 0;
     private static IPlayerCharacter Player => ECommons.GameHelpers.Player.Object;
-
     private static IBattleChara? HostileTarget
     {
         get => Svc.Objects.SearchById(_hostileTargetId) as IBattleChara;
@@ -24,20 +23,19 @@ public class PartyComposition
 
             // Check if player has any buff from our list, and it's not about to expire
             var playerHasBuffs = Buffs.Where(buff => buff.Type == StatusType.Buff)
-                .Any(buff => Player.HasStatus(false, buff.Ids) &&
+                .All(buff => Player.HasStatus(false, buff.Ids) &&
                              !Player.WillStatusEnd(0, false, buff.Ids));
 
             // Check if target has any debuff from our list, and it's not about to expire
             var targetHasDebuffs = HostileTarget != null &&
                                    Buffs.Where(buff => buff.Type == StatusType.Debuff)
-                                       .Any(buff => HostileTarget.HasStatus(false, buff.Ids) &&
+                                       .All(buff => HostileTarget.HasStatus(false, buff.Ids) &&
                                                     !HostileTarget.WillStatusEnd(0, false, buff.Ids));
             return playerHasBuffs || targetHasDebuffs;
         }
     }
 
     public static List<StatusInfo> Buffs { get; } = [];
-
     public static void StatusList()
     {
         Buffs.Clear();
@@ -61,32 +59,18 @@ public class PartyComposition
     private static readonly Dictionary<string, List<StatusInfo>> JobBuffs = new()
     {
         { "AST", [new StatusInfo("Divination", "AST", StatusType.Buff, StatusID.Divination)] },
-        { "BRD", [
-                new StatusInfo("Battle Voice", "BRD", StatusType.Buff, StatusID.BattleVoice),
-                new StatusInfo("Radiant Finale", "BRD", StatusType.Buff, StatusID.RadiantFinale_2964,
-                    StatusID.RadiantFinale)]
-        },
+        { "BRD", [new StatusInfo("Battle Voice", "BRD", StatusType.Buff, StatusID.BattleVoice),
+            new StatusInfo("Radiant Finale", "BRD", StatusType.Buff, StatusID.RadiantFinale_2964,
+                    StatusID.RadiantFinale)] },
         { "DNC", [new StatusInfo("Technical Finish", "DNC", StatusType.Buff, StatusID.TechnicalFinish)] },
         { "DRG", [new StatusInfo("Battle Litany", "DRG", StatusType.Buff, StatusID.BattleLitany)] },
         { "MNK", [new StatusInfo("Brotherhood", "MNK", StatusType.Buff, StatusID.Brotherhood)] },
-        {
-            "NIN", [
-                new StatusInfo("Mug", "NIN", StatusType.Debuff, StatusID.Mug),
-                new StatusInfo("Dokumori", "NIN", StatusType.Debuff, StatusID.Dokumori, StatusID.Dokumori_4303)
-            ]
-        },
+        { "NIN", [new StatusInfo("Mug", "NIN", StatusType.Debuff, StatusID.Mug),
+            new StatusInfo("Dokumori", "NIN", StatusType.Debuff, StatusID.Dokumori, StatusID.Dokumori_4303)] },
         { "PCT", [new StatusInfo("Starry Muse", "PCT", StatusType.Buff, StatusID.StarryMuse)] },
         { "RPR", [new StatusInfo("Arcane Circle", "RPR", StatusType.Buff, StatusID.ArcaneCircle)] },
-        {
-            "RDM", [new StatusInfo("Embolden", "RDM", StatusType.Buff, StatusID.Embolden, StatusID.Embolden_1297)]
-        },
-        {
-            "SCH",
-            [
-                new StatusInfo("Chain Stratagem", "SCH", StatusType.Debuff, StatusID.ChainStratagem,
-                    StatusID.ChainStratagem_1406)
-            ]
-        },
+        { "RDM", [new StatusInfo("Embolden", "RDM", StatusType.Buff, StatusID.Embolden, StatusID.Embolden_1297)] },
+        { "SCH", [new StatusInfo("Chain Stratagem", "SCH", StatusType.Debuff, StatusID.ChainStratagem, StatusID.ChainStratagem_1406)] },
         { "SMN", [new StatusInfo("Searing Light", "SMN", StatusType.Buff, StatusID.SearingLight)] }
     };
 

--- a/ArgentiRotations/Common/RotationDebugManager.cs
+++ b/ArgentiRotations/Common/RotationDebugManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
+using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Colors;
 
 namespace ArgentiRotations.Common;

--- a/ArgentiRotations/Ranged/Bard/BardStatusWindow.cs
+++ b/ArgentiRotations/Ranged/Bard/BardStatusWindow.cs
@@ -1,7 +1,6 @@
-using System.Globalization;
 using ArgentiRotations.Common;
 using Dalamud.Interface.Colors;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 
 namespace ArgentiRotations.Ranged;
 
@@ -17,7 +16,7 @@ public sealed partial class ChurinBRD
     
 #endregion
     #region Status Window Override
-    public override void DisplayStatus()
+    public override void DisplayRotationStatus()
     {
         try
         {
@@ -178,7 +177,7 @@ public sealed partial class ChurinBRD
                 ImGui.NextColumn();
 
                 // Reset columns
-                ImGui.Columns(1);
+                ImGui.Columns();
                 ImGui.TreePop();
             }
 
@@ -222,7 +221,7 @@ public sealed partial class ChurinBRD
                 ImGui.NextColumn();
 
                 // Reset columns
-                ImGui.Columns(1);
+                ImGui.Columns();
                 ImGui.TreePop();
             }
         }

--- a/ArgentiRotations/Ranged/Bard/ChurinBRD.cs
+++ b/ArgentiRotations/Ranged/Bard/ChurinBRD.cs
@@ -3,10 +3,10 @@ using FFXIVClientStructs.FFXIV.Client.Game;
 
 namespace ArgentiRotations.Ranged;
 
-[Rotation("Churin BRD", CombatType.PvE, GameVersion = "7.2.5",
+[Rotation("Churin BRD", CombatType.PvE, GameVersion = "7.3",
     Description = "I sing the body electric. I gasp the body organic. I miss the body remembered.")]
 [SourceCode(Path = "main/ArgentiRotations/Ranged/Bard/ChurinBRD.cs")]
-[Api(5)]
+[Api(6)]
 public sealed partial class ChurinBRD : BardRotation
 {
     #region Properties

--- a/ArgentiRotations/Ranged/Dancer/ChurinDNC.cs
+++ b/ArgentiRotations/Ranged/Dancer/ChurinDNC.cs
@@ -2,9 +2,9 @@ using System.ComponentModel;
 
 namespace ArgentiRotations.Ranged;
 
-[Rotation("Churin DNC", CombatType.PvE, GameVersion = "7.2.5", Description = "Candles lit, runes drawn upon the floor, sacrifice prepared. Everything is ready for the summoning. I begin the incantation: \"Shakira, Shakira!\"")]
+[Rotation("Churin DNC", CombatType.PvE, GameVersion = "7.3", Description = "Candles lit, runes drawn upon the floor, sacrifice prepared. Everything is ready for the summoning. I begin the incantation: \"Shakira, Shakira!\"")]
 [SourceCode(Path = "main/ArgentiRotations/Ranged/Dancer/ChurinDNC.cs")]
-[Api(5)]
+[Api(6)]
 public sealed partial class ChurinDNC : DancerRotation
 {
     #region Properties
@@ -23,7 +23,7 @@ public sealed partial class ChurinDNC : DancerRotation
     #endregion
 
     #region Status Booleans
-    private bool InTwoMinuteWindow => HasTechnicalStep || HasTechnicalStep && CompletedSteps == 4 || IsLastGCD(ActionID.TechnicalStepPvE);
+    private static bool InTwoMinuteWindow => HasTechnicalStep || HasTechnicalStep && CompletedSteps == 4 || IsLastGCD(ActionID.TechnicalStepPvE);
     private bool InOddMinuteWindow => TechnicalStepPvE.Cooldown.IsCoolingDown && FlourishPvE.Cooldown.IsCoolingDown && HasStandardStep;
     private static bool HasTillana => Player.HasStatus(true, StatusID.FlourishingFinish) && !Player.WillStatusEnd(0, true, StatusID.FlourishingFinish);
     private static bool IsBurstPhase => HasDevilment && HasTechnicalFinish;
@@ -669,7 +669,6 @@ public sealed partial class ChurinDNC : DancerRotation
     private bool TryUsePotion(out IAction? act)
     {
         act = null;
-        if (IsMedicated) return false;
 
         for (var i = 0; i < _potions.Count; i++)
         {
@@ -688,6 +687,12 @@ public sealed partial class ChurinDNC : DancerRotation
             else
             {
                 canUse = InCombat && CombatTime >= potionTimeInSeconds && CombatTime <= potionTimeInSeconds + 59;
+            }
+
+            if (IsMedicated && canUse)
+            {
+                _potions[i] = (time, enabled, true);
+                continue;
             }
 
             if (!canUse) continue;

--- a/ArgentiRotations/Ranged/Dancer/DancerStatusWindow.cs
+++ b/ArgentiRotations/Ranged/Dancer/DancerStatusWindow.cs
@@ -1,5 +1,6 @@
 ﻿using ArgentiRotations.Common;
 using Dalamud.Interface.Colors;
+using Dalamud.Bindings.ImGui;
 
 namespace ArgentiRotations.Ranged;
 
@@ -8,11 +9,10 @@ public sealed partial class ChurinDNC
     #region Fields
     private Vector4[] _shouldUseConditions = [];
     private Vector4[] _statusConditions = [];
-
     #endregion
     #region Status Window Override
 
-    public override void DisplayStatus()
+    public override void DisplayRotationStatus()
     {
         try
         {
@@ -67,11 +67,12 @@ public sealed partial class ChurinDNC
             ImGui.TableSetupColumn("Buffs Provided");
             ImGui.TableHeadersRow();
 
-            if (PartyComposition.Count == 0)
+            if (PartyComposition == null || PartyComposition.Count == 0)
             {
                 ImGui.TableNextRow();
                 ImGui.TableSetColumnIndex(0);
-                ImGui.Text(Player.ClassJob.Value.GetJobRole().ToString());
+                var jobRole = Player.ClassJob.Value.GetJobRole().ToString();
+                ImGui.Text(jobRole);
 
                 ImGui.TableSetColumnIndex(1);
                 var jobAbbr = Player.ClassJob.Value.Abbreviation.ToString();
@@ -87,25 +88,29 @@ public sealed partial class ChurinDNC
                 ImGui.Text(buffText);
             }
 
-            foreach (var member in PartyComposition)
+            if (PartyComposition is not null or { Count: > 0 })
             {
-                ImGui.TableNextRow();
+                foreach (var member in PartyComposition)
+                {
+                    ImGui.TableNextRow();
 
-                ImGui.TableSetColumnIndex(0);
-                ImGui.Text(member.Value.GetJobRole().ToString());
+                    ImGui.TableSetColumnIndex(0);
+                    var role = member.Value.GetJobRole().ToString();
+                    ImGui.Text(role);
 
-                ImGui.TableSetColumnIndex(1);
-                var jobAbbr = member.Value.Abbreviation.ToString();
-                ImGui.Text(jobAbbr);
+                    ImGui.TableSetColumnIndex(1);
+                    var jobAbbr = member.Value.Abbreviation.ToString();
+                    ImGui.Text(jobAbbr);
 
-                ImGui.TableSetColumnIndex(2);
-                var buffs = ArgentiRotations.Common.PartyComposition.Buffs
-                    .Where(b => b.JobAbbr == jobAbbr)
-                    .Select(b => b.Name)
-                    .ToList();
+                    ImGui.TableSetColumnIndex(2);
+                    var buffs = ArgentiRotations.Common.PartyComposition.Buffs
+                        .Where(b => b.JobAbbr == jobAbbr)
+                        .Select(b => b.Name)
+                        .ToList();
 
-                var buffText = buffs.Count != 0 ? string.Join(", ", buffs) : "None";
-                ImGui.Text(buffText);
+                    var buffText = buffs.Count != 0 ? string.Join(", ", buffs) : "None";
+                    ImGui.Text(buffText);
+                }
             }
         }
         ImGui.EndTable();
@@ -168,7 +173,7 @@ public sealed partial class ChurinDNC
                 ImGui.TextColored(_shouldUseConditions[8], TechnicalStepPvE.Cooldown.WillHaveOneCharge( 0.5f).ToString());
                 ImGui.NextColumn();
 
-                ImGui.Columns(1);
+                ImGui.Columns();
                 DrawCombatStatusText();
             }
             ImGui.EndGroup();
@@ -240,7 +245,7 @@ public sealed partial class ChurinDNC
                 ImGui.NextColumn();
 
                 // Reset columns
-                ImGui.Columns(1);
+                ImGui.Columns();
                 ImGui.TreePop();
             }
             if (ImGui.TreeNode("Status Booleans"))
@@ -304,7 +309,7 @@ public sealed partial class ChurinDNC
 
 
                 // Reset columns
-                ImGui.Columns(1);
+                ImGui.Columns();
                 ImGui.TreePop();
             }
         }

--- a/ArgentiRotations/Ranged/Machinist/ChurinMCH.cs
+++ b/ArgentiRotations/Ranged/Machinist/ChurinMCH.cs
@@ -3,9 +3,9 @@ using FFXIVClientStructs.FFXIV.Client.Game;
 
 namespace ArgentiRotations.Ranged;
 
-[Rotation("Churin MCH", CombatType.PvE, GameVersion = "7.2.5", Description = "Be the angel with a shotgun!")]
+[Rotation("Churin MCH", CombatType.PvE, GameVersion = "7.3", Description = "Kill it with kindness. And if that fails, kill it with sharp sticks or knives...or guns!")]
 [SourceCode(Path = "ArgentiRotations/Ranged/Machinist/ChurinMCH.cs")]
-[Api(5)]
+[Api(6)]
 public sealed partial class ChurinMCH: MachinistRotation
 {
     #region Properties
@@ -18,6 +18,7 @@ public sealed partial class ChurinMCH: MachinistRotation
     private bool InOddMinuteWindow => !InTwoMinuteWindow && AirAnchorPvE.Cooldown.IsCoolingDown && AirAnchorPvE.Cooldown.WillHaveOneChargeGCD(1);
 
     #endregion
+
     #region Status Booleans
 
     private static bool IsMedicated => Player.HasStatus(true,StatusID.Medicated) ||
@@ -49,8 +50,6 @@ public sealed partial class ChurinMCH: MachinistRotation
     #endregion
 
     #endregion
-
-
 
     #region Potion Properties
     private enum PotionTimings

--- a/ArgentiRotations/Ranged/Machinist/MachinistStatusWindow.cs
+++ b/ArgentiRotations/Ranged/Machinist/MachinistStatusWindow.cs
@@ -1,4 +1,5 @@
 ﻿using ArgentiRotations.Common;
+using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Colors;
 
 namespace ArgentiRotations.Ranged;
@@ -57,7 +58,7 @@ public sealed partial class ChurinMCH
             ImGui.Text($"{diff:F1} seconds");
             ImGui.NextColumn();
             ImGui.TextColored(ImGuiColors.ParsedGold, $"Last Summon Battery Power: {LastSummonBatteryPower}");
-            ImGui.Columns(1);
+            ImGui.Columns();
             DrawCombatStatusText();
         }
         ImGui.EndGroup();
@@ -281,7 +282,7 @@ public sealed partial class ChurinMCH
                 ImGui.NextColumn();
 
                 // Reset columns
-                ImGui.Columns(1);
+                ImGui.Columns();
                 ImGui.TreePop();
             }
             ImGui.TreePop();
@@ -347,7 +348,7 @@ public sealed partial class ChurinMCH
     }
 
 
-    public override void DisplayStatus()
+    public override void DisplayRotationStatus()
     {
         try
         {

--- a/ArgentiRotations/Tank/Dark Knight/ChurinDRK.cs
+++ b/ArgentiRotations/Tank/Dark Knight/ChurinDRK.cs
@@ -1,0 +1,533 @@
+﻿using System.ComponentModel;
+using FFXIVClientStructs.FFXIV.Client.Game;
+
+namespace ArgentiRotations.Tank;
+
+[Rotation("ChurinDRK", CombatType.PvE, GameVersion = "7.3", Description = "Find it in your heart. You'll need to break past the ribs and then scoop it out, but it's in there, and you need to find it. Quickly.")]
+[SourceCode(Path = "main/ArgentiRotations/Tank/ChurinDRK.cs")]
+[Api(6)]
+public sealed partial class ChurinDRK : DarkKnightRotation
+{
+    #region Properties
+    private static bool HasBuffs => Common.PartyComposition.HasBuffs;
+    private static bool HasDisesteem => Player.HasStatus(true, StatusID.Scorn);
+    private bool InBurstWindow => DeliriumPvE.Cooldown.IsCoolingDown && !DeliriumPvE.Cooldown.ElapsedAfter(20) && (LivingShadowPvE.EnoughLevel && ShadowTime is > 0 and < 15 || !LivingShadowPvE.EnoughLevel) || HasBuffs;
+    private static bool InOddWindow(IBaseAction action) => action.Cooldown.IsCoolingDown && action.Cooldown.ElapsedAfter(30) && !action.Cooldown.ElapsedAfter(90);
+    private static bool CanFitSksGCD(float duration, int extraGCDs = 0) => WeaponRemain + ActionManager.GetAdjustedRecastTime(ActionType.Action, 3617U) * extraGCDs < duration;
+    private static bool IsMedicated => Player.HasStatus(true, StatusID.Medicated) && !Player.WillStatusEnd(0, true, StatusID.Medicated);
+
+    #region Enums
+    private enum MpStrategy
+    {
+        [Description("Optimal")] Optimal,
+        [Description("Auto at 3000+ MP")] Auto3K,
+        [Description("Auto at 6000+ MP")] Auto6K,
+        [Description("Auto at 9000+ MP")] Auto9K,
+        [Description("Auto when about to cap")] AutoRefresh,
+        [Description("Force Edge of Darkness")] ForceEdge,
+        [Description("Force Flood of Darkness")] ForceFlood
+    }
+
+    private enum BloodStrategy
+    {
+        [Description("Automatic")] Automatic,
+        [Description("Use ASAP")] Asap,
+        [Description("Conserve for burst")] Conserve,
+        [Description("Only Bloodspiller")] OnlyBloodspiller,
+        [Description("Only Quietus")] OnlyQuietus
+    }
+
+    #endregion
+
+
+    #region Potions
+    private enum PotionTimings
+    {
+        [Description("None")] None,
+        [Description("Opener and Six Minutes")] ZeroSix,
+        [Description("Two Minutes and Eight Minutes")] TwoEight,
+        [Description("Opener, Five Minutes and Ten Minutes")] ZeroFiveTen,
+        [Description("Custom - set values below")] Custom
+    }
+    private readonly List<(int Time, bool Enabled, bool Used)> _potions = [];
+
+    private void InitializePotions()
+    {
+        _potions.Clear();
+        switch (PotionTiming)
+        {
+            case PotionTimings.ZeroSix:
+                _potions.Add((0, true, false));
+                _potions.Add((6, true, false));
+                break;
+            case PotionTimings.TwoEight:
+                _potions.Add((2, true, false));
+                _potions.Add((8, true, false));
+                break;
+            case PotionTimings.ZeroFiveTen:
+                _potions.Add((0, true, false));
+                _potions.Add((5, true, false));
+                _potions.Add((10, true, false));
+                break;
+            case PotionTimings.Custom:
+                if (CustomEnableFirstPotion) _potions.Add((CustomFirstPotionTime, true, false));
+                if (CustomEnableSecondPotion) _potions.Add((CustomSecondPotionTime, true, false));
+                if (CustomEnableThirdPotion) _potions.Add((CustomThirdPotionTime, true, false));
+                break;
+        }
+    }
+
+
+
+    #endregion
+    #endregion
+
+    #region Config Options
+
+    [RotationConfig(CombatType.PvE, Name = "MP Spending Strategy")]
+    private MpStrategy MpSpendingStrategy { get; set; } = MpStrategy.Optimal;
+
+    [RotationConfig(CombatType.PvE, Name = "Blood Gauge Strategy")]
+    private BloodStrategy BloodSpendingStrategy { get; set; } = BloodStrategy.Automatic;
+
+    [RotationConfig(CombatType.PvE, Name = "Use The Blackest Night on lowest HP party member during AOE scenarios")]
+    private bool BlackLantern { get; set; } = false;
+
+    [Range(0, 1, ConfigUnitType.Percent)]
+    [RotationConfig(CombatType.PvE, Name = "Target health threshold needed to use Blackest Night with above option")]
+    private float BlackLanternRatio { get; set; } = 0.5f;
+
+    [RotationConfig(CombatType.PvE, Name = "Potion Presets")]
+    private PotionTimings PotionTiming { get; set; } = PotionTimings.None;
+
+    [RotationConfig(CombatType.PvE, Name = "Enable First Potion for Custom Potion Timings?")]
+    private bool CustomEnableFirstPotion { get; set; } = true;
+
+    [Range(0, 20, ConfigUnitType.None, 1)]
+    [RotationConfig(CombatType.PvE, Name = "First Potion Usage for custom timings - enter time in minutes")]
+    private int CustomFirstPotionTime { get; set; } = 0;
+
+    [RotationConfig(CombatType.PvE, Name = "Enable Second Potion for Custom Potion Timings?")]
+    private bool CustomEnableSecondPotion { get; set; } = true;
+
+    [Range(0, 20, ConfigUnitType.None, 1)]
+    [RotationConfig(CombatType.PvE, Name = "Second Potion Usage for custom timings - enter time in minutes")]
+    private int CustomSecondPotionTime { get; set; } = 0;
+
+    [RotationConfig(CombatType.PvE, Name = "Enable Third Potion for Custom Potion Timings?")]
+    private bool CustomEnableThirdPotion { get; set; } = true;
+
+    [Range(0, 20, ConfigUnitType.None, 1)]
+    [RotationConfig(CombatType.PvE, Name = "Third Potion Usage for custom timings - enter time in minutes")]
+    private int CustomThirdPotionTime { get; set; } = 0;
+
+    #endregion
+
+    #region Countdown Logic
+    // Countdown logic to prepare for combat.
+    // Includes logic for using Provoke, tank stances, and burst medicines.
+    protected override IAction? CountDownAction(float remainTime)
+    {
+        InitializePotions();
+        UpdatePotions();
+        if (remainTime <= 3 && HasTankStance && TheBlackestNightPvE.CanUse(out var act) ||
+            remainTime <= 1 && UnmendPvE.CanUse(out act) || remainTime <= 1 && !HasWeaved() && TryUsePotion(out act))
+        {
+            return act;
+        }
+
+        return base.CountDownAction(remainTime);
+    }
+    #endregion
+
+    #region oGCD Logic
+    [RotationDesc(ActionID.ShadowstridePvE)]
+    protected override bool MoveForwardAbility(IAction nextGCD, out IAction? act)
+    {
+        return ShadowstridePvE.CanUse(out act) || base.MoveForwardAbility(nextGCD, out act);
+    }
+
+    [RotationDesc(ActionID.DarkMissionaryPvE, ActionID.ReprisalPvE)]
+    protected override bool DefenseAreaAbility(IAction nextGCD, out IAction? act)
+    {
+        switch (InBurstWindow)
+        {
+            case false when DarkMissionaryPvE.CanUse(out act):
+            case false when ReprisalPvE.CanUse(out act, skipAoeCheck: true):
+            case false when ShouldUseMp(MpSpendingStrategy) && BlackLantern && TheBlackestNightPvE.CanUse(out act) && TheBlackestNightPvE.Target.Target == LowestHealthPartyMember &&
+                            TheBlackestNightPvE.Target.Target.GetHealthRatio() <= BlackLanternRatio:
+                return true;
+            default:
+                return base.DefenseAreaAbility(nextGCD, out act);
+        }
+    }
+
+    [RotationDesc(ActionID.OblationPvE, ActionID.TheBlackestNightPvE, ActionID.DarkMindPvE, ActionID.ShadowWallPvE, ActionID.ShadowedVigilPvE, ActionID.RampartPvE, ActionID.ReprisalPvE)]
+    protected override bool DefenseSingleAbility(IAction nextGCD, out IAction? act)
+    {
+        //10
+        if (OblationPvE.CanUse(out act, usedUp: true, skipStatusProvideCheck: false))
+        {
+            return true;
+        }
+
+        if (ShouldUseMp(MpSpendingStrategy) && TheBlackestNightPvE.CanUse(out act))
+        {
+            return true;
+        }
+
+        if (ShouldUseMp(MpSpendingStrategy) &&
+            TheBlackestNightPvE.CanUse(out act) && TheBlackestNightPvE.Target.Target == Player)
+        {
+            return true;
+        }
+        //20
+        if (DarkMindPvE.CanUse(out act))
+        {
+            return true;
+        }
+
+        //30
+        if ((!RampartPvE.Cooldown.IsCoolingDown || RampartPvE.Cooldown.ElapsedAfter(60)) && ShadowWallPvE.CanUse(out act))
+        {
+            return true;
+        }
+
+        if ((!RampartPvE.Cooldown.IsCoolingDown || RampartPvE.Cooldown.ElapsedAfter(60)) && ShadowedVigilPvE.CanUse(out act))
+        {
+            return true;
+        }
+
+        //20
+        if (ShadowWallPvE.Cooldown.IsCoolingDown && ShadowWallPvE.Cooldown.ElapsedAfter(60) && RampartPvE.CanUse(out act))
+        {
+            return true;
+        }
+
+        if (ShadowedVigilPvE.Cooldown.IsCoolingDown && ShadowedVigilPvE.Cooldown.ElapsedAfter(60) && RampartPvE.CanUse(out act))
+        {
+            return true;
+        }
+
+        return ReprisalPvE.CanUse(out act) || base.DefenseSingleAbility(nextGCD, out act);
+    }
+
+    protected override bool AttackAbility(IAction nextGCD, out IAction? act)
+    {
+        return  TryUseEdgeOfShadow(out act) ||
+                TryUseLivingShadow(out act) ||
+                TryUseDelirium(out act) ||
+                TryUseSaltedEarth(out act) ||
+                TryUseShadowbringer(out act) ||
+                TryUseCarveAndSpit(out act) ||
+                base.AttackAbility(nextGCD, out act);
+    }
+    #endregion
+
+    #region GCD Logic
+    protected override bool GeneralGCD(out IAction? act)
+    {
+        return TryUseDisesteem(out act) ||
+               TryUseDeliriumCombo(out act) ||
+               TryUseBlood(out act) ||
+               TryUseFiller(out act) ||
+               base.GeneralGCD(out act);
+    }
+    #endregion
+
+    #region Extra Methods
+    #region GCD Skills
+    private bool TryUseDisesteem(out IAction? act)
+    {
+        act = null;
+        if (!HasDisesteem) return false;
+
+        if ((LivingShadowPvE.Cooldown.ElapsedAfterGCD(3) && CurrentTarget?.DistanceToPlayer() > 3 || LivingShadowPvE.Cooldown.ElapsedAfterGCD(3) || HasBuffs) && LiveComboTime <= 0)
+        {
+            return DisesteemPvE.CanUse(out act, skipComboCheck: true, skipAoeCheck: true);
+        }
+
+        return false;
+    }
+    private bool TryUseBlood(out IAction? act)
+    {
+        act = null;
+        if (ShouldUseBlood(BloodSpendingStrategy, CurrentTarget))
+        {
+            return QuietusPvE.CanUse(out act) ||
+                   BloodspillerPvE.CanUse(out act, skipComboCheck: true);
+        }
+        return false;
+    }
+    private bool TryUseDeliriumCombo(out IAction? act)
+    {
+        act = null;
+        if ((CurrentMp >= 9600 || !HasDelirium ) && DeliriumPvE.EnoughLevel) return false;
+
+        if (!DeliriumPvE.EnoughLevel && BloodWeaponPvE.EnoughLevel)
+        {
+            if (BloodWeaponStacks > 0 && BloodspillerPvE.CanUse(out act))
+            {
+                return true;
+            }
+        }
+
+        if (HasDelirium && LiveComboTime <= 0)
+        {
+            return ImpalementReady && ImpalementPvE.CanUse(out act) ||
+                   TorcleaverReady && TorcleaverPvE.CanUse(out act, skipComboCheck: true) ||
+                   ComeuppanceReady && ComeuppancePvE.CanUse(out act, skipComboCheck: true) ||
+                   ScarletDeliriumReady && ScarletDeliriumPvE.CanUse(out act, skipComboCheck: true);
+        }
+
+        return false;
+    }
+    private bool TryUseFiller(out IAction? act)
+    {
+        act = null;
+        if (HasDelirium) return false;
+
+        return StalwartSoulPvE.CanUse(out act) ||
+               UnleashPvE.CanUse(out act) ||
+               SouleaterPvE.CanUse(out act) ||
+               SyphonStrikePvE.CanUse(out act) ||
+               HardSlashPvE.CanUse(out act) ||
+               UnmendPvE.CanUse(out act);
+    }
+
+    #endregion
+    #region oGCD Skills
+    private bool TryUseEdgeOfShadow(out IAction? act)
+    {
+        act = null;
+        if (ShouldUseMp(MpSpendingStrategy))
+        {
+            return FloodOfDarknessPvE.CanUse(out act) ||
+                   EdgeOfDarknessPvE.CanUse(out act);
+        }
+        return false;
+    }
+    private bool TryUseLivingShadow(out IAction? act)
+    {
+        if (InCombat && DarkSideTime > 0)
+        {
+            return LivingShadowPvE.CanUse(out act);
+        }
+        act = null;
+        return false;
+    }
+    private bool TryUseShadowbringer(out IAction? act)
+    {
+        if (HasBuffs || InBurstWindow && ShadowbringerPvE.Cooldown.CurrentCharges > 0)
+        {
+            return ShadowbringerPvE.CanUse(out act, skipAoeCheck: true);
+        }
+
+        if (ShadowbringerPvE.Cooldown.CurrentCharges == 1 && ShadowbringerPvE.Cooldown.WillHaveXChargesGCD(2, 1))
+        {
+            return ShadowbringerPvE.CanUse(out act, usedUp: true, skipAoeCheck: true);
+        }
+        act = null;
+        return false;
+    }
+    private bool TryUseSaltedEarth(out IAction? act)
+    {
+        if (HasBuffs || !CombatElapsedLessGCD(3) || InBurstWindow)
+        {
+            return IsInHighEndDuty && SaltedEarthPvE.CanUse(out act, skipAoeCheck: true) ||
+                   !IsInHighEndDuty && !IsMoving && SaltedEarthPvE.CanUse(out act, skipAoeCheck: true) ||
+                   SaltAndDarknessPvE.CanUse(out act);
+        }
+        act = null;
+        return false;
+    }
+    private bool TryUseDelirium (out IAction? act)
+    {
+        act = null;
+        if (!DeliriumPvE.EnoughLevel && BloodWeaponPvE.EnoughLevel && BloodWeaponPvE.CanUse(out act))
+        {
+            return true;
+        }
+
+        return !CombatElapsedLessGCD(3) && DeliriumPvE.CanUse(out act, skipComboCheck: true);
+    }
+    private bool TryUseCarveAndSpit(out IAction? act)
+    {
+        act = null;
+        if (InBurstWindow || DeliriumPvE.Cooldown.IsCoolingDown && !DeliriumPvE.Cooldown.WillHaveOneCharge(20))
+        {
+            return AbyssalDrainPvE.CanUse(out act) ||
+                   CarveAndSpitPvE.CanUse(out act);
+        }
+
+        return false;
+    }
+
+    #endregion
+    #region Miscellaneous Methods
+    private bool TryUsePotion(out IAction? act)
+    {
+        act = null;
+        if (IsMedicated) return false;
+
+        for (var i = 0; i < _potions.Count; i++)
+        {
+            var (time, enabled, used) = _potions[i];
+            if (!enabled || used) continue;
+
+            var potionTimeInSeconds = time * 60;
+            var isOpenerPotion = potionTimeInSeconds == 0;
+            var isEvenMinutePotion = time % 2 == 0;
+
+            bool canUse;
+            if (isOpenerPotion)
+            {
+                canUse = InCombat && IsLastGCD(ActionID.UnmendPvE) && HasWeaved();
+            }
+            else
+            {
+                canUse = InCombat && CombatTime >= potionTimeInSeconds && CombatTime <= potionTimeInSeconds + 59;
+            }
+
+            if (!canUse) continue;
+
+            var condition = (isEvenMinutePotion ? InBurstWindow : InOddWindow(LivingShadowPvE)) || isOpenerPotion || InBurstWindow;
+
+            if (condition && UseBurstMedicine(out act, false))
+            {
+                _potions[i] = (time, enabled, true);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private PotionTimings _lastPotionTiming;
+    private int _lastFirst, _lastSecond, _lastThird;
+
+    private void UpdatePotions()
+    {
+        if (_lastPotionTiming != PotionTiming ||
+            _lastFirst != CustomFirstPotionTime ||
+            _lastSecond != CustomSecondPotionTime ||
+            _lastThird != CustomThirdPotionTime)
+        {
+            var oldPotions = new List<(int Time, bool Enabled, bool Used)>(_potions);
+
+            InitializePotions();
+
+            // Merge used state if in combat
+            if (InCombat)
+                for (var i = 0; i < _potions.Count; i++)
+                {
+                    var (time, enabled, _) = _potions[i];
+                    var old = oldPotions.FirstOrDefault(p => p.Time == time);
+                    if (old.Time == time)
+                        _potions[i] = (time, enabled, old.Used);
+                }
+
+            _lastPotionTiming = PotionTiming;
+            _lastFirst = CustomFirstPotionTime;
+            _lastSecond = CustomSecondPotionTime;
+            _lastThird = CustomThirdPotionTime;
+        }
+    }
+    private bool ShouldUseMp(MpStrategy strategy)
+{
+    var riskingMp = CurrentMp >= 8500;
+
+    if (!FloodOfShadowPvE.EnoughLevel)
+        return false;
+
+    if (strategy == MpStrategy.Optimal)
+    {
+        if (riskingMp)
+            return CurrentMp >= 3000 || HasDarkArts;
+
+        if (DeliriumPvE.EnoughLevel)
+        {
+            // For Dark Arts
+            if (TheBlackestNightPvE.EnoughLevel && HasDarkArts)
+            {
+                if (HasDelirium || !DeliriumPvE.Cooldown.WillHaveOneCharge(DarkSideTime + WeaponTotal))
+                    return CurrentMp >= 3000;
+            }
+
+            // 1m window - 2 uses expected
+            if (!DeliriumPvE.Cooldown.WillHaveOneCharge(40) && InOddWindow(LivingShadowPvE))
+                return CurrentMp >= 6000;
+
+            // 2m window - 4 uses expected; 5 with Dark Arts
+            if (!DeliriumPvE.Cooldown.WillHaveOneCharge(40) && !InOddWindow(LivingShadowPvE))
+                return CurrentMp >= 3000;
+        }
+
+        // If no Delirium, just use it whenever we have more than 3000 MP
+        if (!DeliriumPvE.EnoughLevel)
+            return CurrentMp >= 3000;
+    }
+
+    return strategy switch
+    {
+        MpStrategy.Auto3K => CurrentMp >= 3000,
+        MpStrategy.Auto6K => CurrentMp >= 6000,
+        MpStrategy.Auto9K => CurrentMp >= 9000,
+        MpStrategy.AutoRefresh => riskingMp,
+        MpStrategy.ForceEdge => EdgeOfDarknessPvE.EnoughLevel && (CurrentMp >= 3000 || HasDarkArts),
+        MpStrategy.ForceFlood => FloodOfDarknessPvE.EnoughLevel && (CurrentMp >= 3000 || HasDarkArts),
+        _ => false
+    };
+}
+
+    private bool ShouldUseBlood(BloodStrategy strategy, IBattleChara? target)
+    {
+        var riskingBlood = Blood >= 90;
+        var minimum = (BloodspillerPvE.EnoughLevel || QuietusPvE.EnoughLevel) && (Blood >= 50 || HasDelirium);
+        var inMeleeRange = target != null && target.DistanceToPlayer() <= 3;
+
+        // Basic condition for using blood
+        var condition = InCombat && target != null && inMeleeRange && minimum &&
+                   DarkSideTime > 0 && (riskingBlood || !InOddWindow(LivingShadowPvE) ?
+                       !CanFitSksGCD(Player.StatusTime(true, StatusID.Delirium_3836), 3) ||
+                       HasBuffs : minimum);
+
+        return strategy switch
+        {
+            BloodStrategy.Automatic => condition,
+            BloodStrategy.OnlyBloodspiller => condition && target!.DistanceToPlayer() <= 3,
+            BloodStrategy.OnlyQuietus => condition && NumberOfAllHostilesInRange > 2,
+            BloodStrategy.Asap => minimum,
+            BloodStrategy.Conserve => riskingBlood || (HasDelirium && Player.StatusTime(true, StatusID.Delirium_3836) > WeaponTotal),
+            _ => false
+        };
+    }
+
+    private List<IBattleChara> _currentParty = [];
+
+    public List<IBattleChara> CurrentParty
+    {
+        get => _currentParty;
+        set
+        {
+            _currentParty = value;
+            var newParty = PartyMembers ?? [Player];
+            IEnumerable<IBattleChara> battleCharas = newParty.ToList();
+            var hasChanged = !_currentParty.ToHashSet().SetEquals(battleCharas);
+
+            if (hasChanged)
+            {
+                _currentParty.Clear();
+                _currentParty.AddRange(battleCharas);
+            }
+
+            if (_currentParty.Count == 0)
+            {
+                _currentParty.Add(Player);
+            }
+        }
+    }
+
+
+    #endregion
+    #endregion
+    }

--- a/ArgentiRotations/Tank/Dark Knight/DarkKnightStatusWindow.cs
+++ b/ArgentiRotations/Tank/Dark Knight/DarkKnightStatusWindow.cs
@@ -1,0 +1,321 @@
+﻿using ArgentiRotations.Common;
+using Dalamud.Bindings.ImGui;
+using Dalamud.Interface.Colors;
+
+namespace ArgentiRotations.Tank;
+
+public sealed partial class ChurinDRK
+{
+    #region Fields
+    private Vector4[] _statusConditions = [];
+
+    #endregion
+    #region Status Window Override
+    public override void DisplayRotationStatus()
+    {
+        try
+        {
+            DisplayStatusHelper.BeginPaddedChild("ChurinDrk Status", true,
+                ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoScrollbar);
+            DrawRotationStatus();
+            DrawPartyCompositionHeader();
+            DrawCombatStatusHeader();
+            DrawPotionStatusHeader();
+            DisplayStatusHelper.EndPaddedChild();
+        }
+        catch (Exception ex)
+        {
+            ImGui.TextColored(ImGuiColors.DalamudRed, $"Error displaying status: {ex.Message}");
+        }
+    }
+    private void DrawRotationStatus()
+    {
+        var text = "Rotation: " + Name;
+        var textSize = ImGui.CalcTextSize(text).X;
+        DisplayStatusHelper.DrawItemMiddle(() =>
+        {
+            ImGui.TextColored(ImGuiColors.HealerGreen, text);
+            DisplayStatusHelper.HoveredTooltip(Description);
+        }, ImGui.GetWindowWidth(), textSize);
+    }
+    #region Party Composition
+    private static void DrawPartyCompositionHeader()
+    {
+        try
+        {
+            ImGui.BeginGroup();
+            if (ImGui.CollapsingHeader("Party Composition", ImGuiTreeNodeFlags.DefaultOpen))
+            {
+                DrawPartyCompositionText();
+            }
+            ImGui.EndGroup();
+        }
+        catch (Exception)
+        {
+            ImGui.TextColored(ImGuiColors.DalamudRed, "Error displaying party composition");
+        }
+    }
+    private static void DrawPartyCompositionText()
+    {
+        ArgentiRotations.Common.PartyComposition.StatusList();
+        if (ImGui.BeginTable("PartyCompositionTable", 3, ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg))
+        {
+            ImGui.TableSetupColumn("Role");
+            ImGui.TableSetupColumn("Job");
+            ImGui.TableSetupColumn("Buffs Provided");
+            ImGui.TableHeadersRow();
+
+            if (PartyComposition.Count == 0)
+            {
+                ImGui.TableNextRow();
+                ImGui.TableSetColumnIndex(0);
+                ImGui.Text(Player.ClassJob.Value.GetJobRole().ToString());
+
+                ImGui.TableSetColumnIndex(1);
+                var jobAbbr = Player.ClassJob.Value.Abbreviation.ToString();
+                ImGui.Text(jobAbbr);
+
+                ImGui.TableSetColumnIndex(2);
+                var buffs = ArgentiRotations.Common.PartyComposition.Buffs
+                    .Where(b => b.JobAbbr == jobAbbr)
+                    .Select(b => b.Name)
+                    .ToList();
+
+                var buffText = buffs.Count != 0 ? string.Join(", ", buffs) : "None";
+                ImGui.Text(buffText);
+            }
+
+            foreach (var member in PartyComposition)
+            {
+                ImGui.TableNextRow();
+
+                ImGui.TableSetColumnIndex(0);
+                ImGui.Text(member.Value.GetJobRole().ToString());
+
+                ImGui.TableSetColumnIndex(1);
+                var jobAbbr = member.Value.Abbreviation.ToString();
+                ImGui.Text(jobAbbr);
+
+                ImGui.TableSetColumnIndex(2);
+                var buffs = ArgentiRotations.Common.PartyComposition.Buffs
+                    .Where(b => b.JobAbbr == jobAbbr)
+                    .Select(b => b.Name)
+                    .ToList();
+
+                var buffText = buffs.Count != 0 ? string.Join(", ", buffs) : "None";
+                ImGui.Text(buffText);
+            }
+        }
+        ImGui.EndTable();
+    }
+
+    #endregion
+    #region Combat Status
+    private void DrawCombatStatusHeader()
+    {
+        try
+        {
+            ImGui.BeginGroup();
+            if (ImGui.CollapsingHeader("Combat Status Details", ImGuiTreeNodeFlags.DefaultOpen))
+            {
+                ImGui.Columns();
+                DrawCombatStatusText();
+            }
+            ImGui.EndGroup();
+        }
+        catch (Exception)
+        {
+            ImGui.TextColored(ImGuiColors.DalamudRed, "Error displaying combat status");
+        }
+    }
+
+    private void DrawCombatStatusText()
+    {
+        try
+        {
+            InitializeColorData();
+            if (ImGui.TreeNode("Rotation Booleans"))
+            {
+                ImGui.Columns(2, "CombatStatusColumns", false);
+
+                // Column headers
+                ImGui.Text("Condition");
+                ImGui.NextColumn();
+                ImGui.Text("Value");
+                ImGui.NextColumn();
+                ImGui.Separator();
+
+                // Reset columns
+                ImGui.Columns();
+                ImGui.TreePop();
+            }
+
+            if (ImGui.TreeNode("Status Booleans"))
+            {
+                ImGui.Columns(2, "StatusColumns", false);
+                ImGui.Text("Status");
+                ImGui.NextColumn();
+                ImGui.Text("Value");
+                ImGui.NextColumn();
+                ImGui.Separator();
+
+                ImGui.TextColored(_statusConditions[0], "Is Medicated:");
+                ImGui.NextColumn();
+                ImGui.TextColored(_statusConditions[0], IsMedicated.ToString());
+                ImGui.NextColumn();
+
+                ImGui.TextColored(_statusConditions[1], "In Burst Window:");
+                ImGui.NextColumn();
+                ImGui.TextColored(_statusConditions[1], InBurstWindow.ToString());
+                ImGui.NextColumn();
+
+                ImGui.TextColored(_statusConditions[2], "Has Party Buffs:");
+                ImGui.NextColumn();
+                ImGui.TextColored(_statusConditions[2], HasBuffs.ToString());
+                ImGui.NextColumn();
+
+                // Reset columns
+                ImGui.Columns();
+                ImGui.TreePop();
+            }
+
+            if (ImGui.TreeNode("Active Buffs/Debuffs"))
+            {
+                ArgentiRotations.Common.PartyComposition.StatusList();
+
+                if (ArgentiRotations.Common.PartyComposition.Buffs.Count == 0)
+                {
+                    ImGui.TextColored(ImGuiColors.DalamudRed, "No active buffs or debuffs found.");
+                }
+                else if (ImGui.BeginTable("ActiveBuffsTable", 3, ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg))
+                {
+                    ImGui.TableSetupColumn("Type");
+                    ImGui.TableSetupColumn("Name");
+                    ImGui.TableSetupColumn("Source");
+                    ImGui.TableHeadersRow();
+
+                    var activeBuffs = ArgentiRotations.Common.PartyComposition.Buffs.Where(b =>
+                        b.Type == StatusType.Buff && Player.HasStatus(false, b.Ids) &&
+                        !Player.WillStatusEnd(0, false, b.Ids));
+                    var activeDebuffs = ArgentiRotations.Common.PartyComposition.Buffs.Where(b =>
+                        b.Type == StatusType.Debuff && HostileTarget != null && HostileTarget.HasStatus(false, b.Ids) &&
+                        !HostileTarget.WillStatusEnd(0, false, b.Ids));
+
+                    var hasActiveEffects = false;
+
+                    foreach (var buff in activeBuffs)
+                    {
+                        hasActiveEffects = true;
+                        ImGui.TableNextRow();
+                        ImGui.TableSetColumnIndex(0);
+                        ImGui.TextColored(ImGuiColors.HealerGreen, "Buff");
+                        ImGui.TableSetColumnIndex(1);
+                        ImGui.Text(buff.Name);
+                        ImGui.TableSetColumnIndex(2);
+                        ImGui.Text(buff.JobAbbr);
+                    }
+
+                    foreach (var debuff in activeDebuffs)
+                    {
+                        hasActiveEffects = true;
+                        ImGui.TableNextRow();
+                        ImGui.TableSetColumnIndex(0);
+                        ImGui.TextColored(ImGuiColors.DalamudRed, "Debuff");
+                        ImGui.TableSetColumnIndex(1);
+                        ImGui.Text(debuff.Name);
+                        ImGui.TableSetColumnIndex(2);
+                        ImGui.Text(debuff.JobAbbr);
+                    }
+
+                    if (!hasActiveEffects)
+                    {
+                        ImGui.TableNextRow();
+                        ImGui.TableSetColumnIndex(0);
+                        ImGui.TableSetColumnIndex(1);
+                        ImGui.TextColored(ImGuiColors.DalamudRed, "No active buffs or debuffs found.");
+                        ImGui.TableSetColumnIndex(2);
+                    }
+
+                    ImGui.EndTable();
+                }
+
+                ImGui.TreePop();
+            }
+
+        }
+        catch (Exception)
+        {
+            ImGui.TextColored(ImGuiColors.DalamudRed, $"Error displaying combat status");
+        }
+    }
+
+    #endregion
+    #region Potion Status
+        private void DrawPotionStatusHeader()
+        {
+            ImGui.BeginGroup();
+            if (ImGui.CollapsingHeader("Potion Status", ImGuiTreeNodeFlags.DefaultOpen))
+            {
+                DrawPotionStatusText();
+            }
+            ImGui.EndGroup();
+        }
+        private void DrawPotionStatusText()
+        {
+            try
+            {
+                if (ImGui.BeginTable("PotionStatusTable", 4, ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg))
+                {
+                    ImGui.TableSetupColumn("Potion");
+                    ImGui.TableSetupColumn("Enabled");
+                    ImGui.TableSetupColumn("Used");
+                    ImGui.TableSetupColumn("Time");
+                    ImGui.TableHeadersRow();
+
+                    var trueColor = ImGuiColors.HealerGreen;
+                    var falseColor = ImGuiColors.DalamudRed;
+
+                    for (var i = 0; i < _potions.Count; i++)
+                    {
+                        var (time, enabled, used) = _potions[i];
+                        ImGui.TableNextRow();
+                        ImGui.TableSetColumnIndex(0);
+                        ImGui.Text($"Potion {i + 1}");
+                        ImGui.TableSetColumnIndex(1);
+                        ImGui.TextColored(GetColor(enabled, trueColor, falseColor), enabled.ToString());
+                        ImGui.TableSetColumnIndex(2);
+                        ImGui.TextColored(GetColor(used, trueColor, falseColor), used.ToString());
+                        ImGui.TableSetColumnIndex(3);
+                        ImGui.Text($"{time} min");
+                    }
+                    ImGui.EndTable();
+                }
+            }
+            catch (Exception ex)
+            {
+                ImGui.TextColored(ImGuiColors.DalamudRed, $"Error displaying potion status: {ex.Message}");
+            }
+        }
+
+        #endregion
+    #endregion
+    #region Status Window Helper Methods
+
+        private static Vector4 GetColor(bool condition, Vector4 trueColor, Vector4 falseColor)
+            => condition ? trueColor : falseColor;
+        private void InitializeColorData()
+        {
+
+            var statusConditions = new[]
+            {
+                IsMedicated, InBurstWindow, HasBuffs
+            };
+
+            _statusConditions = statusConditions
+                .Select(condition => GetColor(condition, ImGuiColors.HealerGreen, ImGuiColors.DalamudRed)).ToArray();
+        }
+
+
+
+        #endregion
+}


### PR DESCRIPTION
This pull request updates the ArgentiRotations plugin for compatibility with Dalamud 13 and FFXIV patch 7.3, refactors several status window and buff/debuff management methods for improved clarity and correctness, and implements fixes for potion usage logic and UI rendering. The most important changes are grouped below:

**Framework and Dependency Updates**

* Upgraded the project SDK to `Dalamud.NET.Sdk/13.0.0` and updated related package references, ensuring compatibility with the latest Dalamud and plugin packaging standards. [[1]](diffhunk://#diff-062dfb040a9df5e3450dc39b26a9b4647bc798bbc6f15ca2f810514baf51bab7L1-R1) [[2]](diffhunk://#diff-062dfb040a9df5e3450dc39b26a9b4647bc798bbc6f15ca2f810514baf51bab7L13-L20)
* Updated rotation classes (`ChurinBRD`, `ChurinDNC`, `ChurinMCH`) to specify `GameVersion = "7.3"` and increased their API version to 6, reflecting support for the latest FFXIV patch. [[1]](diffhunk://#diff-0fc5965f7f92a6b8a387c374bb3934e61406724893c3134bb81f8205cf0f4ba8L6-R9) [[2]](diffhunk://#diff-dc95a0b08dddbd9d2675a3a5c9cccdcf181579ae5f35b14a06de1aa1b7767c5dL5-R7) [[3]](diffhunk://#diff-b3d330bd4e5ae9de60f8f4d125adfa77451a4b6c6a9050521fb09b1a4d28a7c5L6-R8)

**Status Window and UI Refactoring**

* Replaced usage of `ImGuiNET` with `Dalamud.Bindings.ImGui` across multiple files for improved integration and future compatibility. [[1]](diffhunk://#diff-395ddfdd1522180312ef9f7e18a84d7acc8250aa5ef86be6cff523adb8a2166fL1-R1) [[2]](diffhunk://#diff-88a42f5541d8727079a4d80d73f3fcddc275f7cf2fdd426dfaf59bfc97dc652fR2) [[3]](diffhunk://#diff-61bb5900c5a164dd2f8366e1f7ffe05d6e06e334e7bd8fe323340e96adcd1605L1-R3) [[4]](diffhunk://#diff-cbd999154ac33657a5645ee3a8e1c9c24633109f7c9e26446a8b881f98fc2522R3) [[5]](diffhunk://#diff-713664d80e833044b624bac70342bc01e8cf084524b56bc7a388ccb15191e456R2)
* Renamed status display methods from `DisplayStatus` to `DisplayRotationStatus` in Bard and Dancer status windows for clarity and consistency. [[1]](diffhunk://#diff-61bb5900c5a164dd2f8366e1f7ffe05d6e06e334e7bd8fe323340e96adcd1605L20-R19) [[2]](diffhunk://#diff-cbd999154ac33657a5645ee3a8e1c9c24633109f7c9e26446a8b881f98fc2522L11-R15)
* Updated ImGui column reset logic from `ImGui.Columns(1)` to `ImGui.Columns()` in status windows to fix rendering issues and align with current ImGui API. [[1]](diffhunk://#diff-61bb5900c5a164dd2f8366e1f7ffe05d6e06e334e7bd8fe323340e96adcd1605L181-R180) [[2]](diffhunk://#diff-61bb5900c5a164dd2f8366e1f7ffe05d6e06e334e7bd8fe323340e96adcd1605L225-R224) [[3]](diffhunk://#diff-cbd999154ac33657a5645ee3a8e1c9c24633109f7c9e26446a8b881f98fc2522L171-R176) [[4]](diffhunk://#diff-cbd999154ac33657a5645ee3a8e1c9c24633109f7c9e26446a8b881f98fc2522L243-R248) [[5]](diffhunk://#diff-cbd999154ac33657a5645ee3a8e1c9c24633109f7c9e26446a8b881f98fc2522L307-R312)

**Buff/Debuff and Party Composition Logic**

* Changed buff/debuff checks in `PartyComposition.cs` from `.Any()` to `.All()` to ensure all required buffs/debuffs are present and not expiring, improving correctness of status checks.
* Refactored the `JobBuffs` dictionary for improved readability and maintainability by flattening nested initializations.
* Improved party composition UI rendering in Dancer status window to handle null references and empty lists more robustly. [[1]](diffhunk://#diff-cbd999154ac33657a5645ee3a8e1c9c24633109f7c9e26446a8b881f98fc2522L70-R75) [[2]](diffhunk://#diff-cbd999154ac33657a5645ee3a8e1c9c24633109f7c9e26446a8b881f98fc2522R91-R99) [[3]](diffhunk://#diff-cbd999154ac33657a5645ee3a8e1c9c24633109f7c9e26446a8b881f98fc2522R115)

**Potion Usage Logic**

* Fixed potion usage logic in Dancer rotation to correctly handle cases where the player is already medicated, preventing unnecessary potion attempts. [[1]](diffhunk://#diff-dc95a0b08dddbd9d2675a3a5c9cccdcf181579ae5f35b14a06de1aa1b7767c5dL672) [[2]](diffhunk://#diff-dc95a0b08dddbd9d2675a3a5c9cccdcf181579ae5f35b14a06de1aa1b7767c5dR692-R697)

**Minor Code Cleanup**

* Removed unused folders and redundant lines in project files and rotation classes for better maintainability. [[1]](diffhunk://#diff-062dfb040a9df5e3450dc39b26a9b4647bc798bbc6f15ca2f810514baf51bab7L37) [[2]](diffhunk://#diff-0d6765e55999d9082424c355c9740a4e082b242959117805b5662f7d646fb441L10) [[3]](diffhunk://#diff-b3d330bd4e5ae9de60f8f4d125adfa77451a4b6c6a9050521fb09b1a4d28a7c5R21) [[4]](diffhunk://#diff-b3d330bd4e5ae9de60f8f4d125adfa77451a4b6c6a9050521fb09b1a4d28a7c5L53-L54) [[5]](diffhunk://#diff-dc95a0b08dddbd9d2675a3a5c9cccdcf181579ae5f35b14a06de1aa1b7767c5dL26-R26)

These changes collectively improve plugin stability, maintainability, and ensure compatibility with the latest game and plugin framework updates.