### PR TITLE
Minor stuff

### DIFF
--- a/ArgentiRotations/AssemblyInfo.cs
+++ b/ArgentiRotations/AssemblyInfo.cs
@@ -1,3 +1,1 @@
-﻿using System.Runtime.CompilerServices;
-
-[assembly: AssemblyLink(Donate = "", UserName = "aventurescence", Repository = "ArgentiRotations")]
+﻿[assembly: AssemblyLink(Donate = "", UserName = "aventurescence", Repository = "ArgentiRotations")]

--- a/ArgentiRotations/Common/ArgentiUtilities.cs
+++ b/ArgentiRotations/Common/ArgentiUtilities.cs
@@ -1,14 +1,6 @@
 using System.Runtime.InteropServices;
-using Dalamud.Game.ClientState.Party;
-using Dalamud.Plugin.Services;
-using ECommons.ExcelServices;
-using ECommons.GameHelpers;
-using FFXIVClientStructs.FFXIV.Client.Game.Group;
 using FFXIVClientStructs.FFXIV.Client.System.Framework;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
-using FFXIVClientStructs.FFXIV.Client.UI.Arrays;
-using FFXIVClientStructs.FFXIV.Client.UI.Info;
-using Lumina.Text.ReadOnly;
 using Serilog;
 
 namespace ArgentiRotations.Common;

--- a/ArgentiRotations/Common/DisplayStatusHelper.cs
+++ b/ArgentiRotations/Common/DisplayStatusHelper.cs
@@ -1,4 +1,3 @@
-using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;

--- a/ArgentiRotations/Common/RotationDebugManager.cs
+++ b/ArgentiRotations/Common/RotationDebugManager.cs
@@ -1,5 +1,4 @@
 ﻿using System.Runtime.CompilerServices;
-using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Colors;
 
 namespace ArgentiRotations.Common;

--- a/ArgentiRotations/Ranged/Bard/BardStatusWindow.cs
+++ b/ArgentiRotations/Ranged/Bard/BardStatusWindow.cs
@@ -1,6 +1,5 @@
 using ArgentiRotations.Common;
 using Dalamud.Interface.Colors;
-using Dalamud.Bindings.ImGui;
 
 namespace ArgentiRotations.Ranged;
 

--- a/ArgentiRotations/Ranged/Dancer/ChurinDNC.cs
+++ b/ArgentiRotations/Ranged/Dancer/ChurinDNC.cs
@@ -219,7 +219,7 @@ public sealed partial class ChurinDNC : DancerRotation
         if (SwapDancePartner(out act)) return true;
         if (TryUseClosedPosition(out act)) return true;
         if (TryUseDevilment(out act)) return true;
-        if (!CanUseStandardStep || !CanUseTechnicalStep)
+        if (!CanUseStandardStep || !CanUseTechnicalStep || IsDancing)
             return base.EmergencyAbility(nextGCD, out act);
 
         act = null;
@@ -266,7 +266,6 @@ public sealed partial class ChurinDNC : DancerRotation
     #region Extra Methods
 
     #region Dance Partner Logic
-
     private bool TryUseClosedPosition(out IAction? act)
     {
         act = null;
@@ -288,7 +287,6 @@ public sealed partial class ChurinDNC : DancerRotation
     }
 
     #endregion
-
     #region Dance Logic
 
     private bool TryUseDance(out IAction? act)
@@ -345,7 +343,6 @@ public sealed partial class ChurinDNC : DancerRotation
     }
 
     #endregion
-
     #region Burst Logic
     private bool TryUseBurstGCD(out IAction? act)
     {
@@ -425,7 +422,7 @@ public sealed partial class ChurinDNC : DancerRotation
         {
             return Esprit switch
             {
-                >= 0 when HasStarfall && Player.WillStatusEnd(5, true, StatusID.FlourishingStarfall) && DevilmentPvE.Cooldown.RecastTimeElapsed > 5 => true,
+                >= 0 when HasStarfall && (Player.WillStatusEnd(5, true, StatusID.FlourishingStarfall) || DevilmentPvE.Cooldown.RecastTimeElapsed > 5 && !HasFinishingMove) => true,
                 < MidEspritThreshold when !HasFinishingMove || DevilmentPvE.Cooldown.RecastTimeElapsed > 7 => true,
                 > MidEspritThreshold when DevilmentPvE.Cooldown.RecastTimeElapsed > 15 => true,
                 _ => false

--- a/ArgentiRotations/Ranged/Dancer/DancerStatusWindow.cs
+++ b/ArgentiRotations/Ranged/Dancer/DancerStatusWindow.cs
@@ -1,6 +1,5 @@
 ﻿using ArgentiRotations.Common;
 using Dalamud.Interface.Colors;
-using Dalamud.Bindings.ImGui;
 
 namespace ArgentiRotations.Ranged;
 
@@ -11,7 +10,6 @@ public sealed partial class ChurinDNC
     private Vector4[] _statusConditions = [];
     #endregion
     #region Status Window Override
-
     public override void DisplayRotationStatus()
     {
         try
@@ -39,7 +37,6 @@ public sealed partial class ChurinDNC
             DisplayStatusHelper.HoveredTooltip(Description);
         }, ImGui.GetWindowWidth(), textSize);
     }
-
     #region Party Composition
     private static void DrawPartyCompositionHeader()
     {
@@ -115,7 +112,6 @@ public sealed partial class ChurinDNC
         }
         ImGui.EndTable();
     }
-
     #endregion
     #region Combat Status
     private void DrawCombatStatusHeader()
@@ -366,8 +362,6 @@ public sealed partial class ChurinDNC
         }
     }
     #endregion
-
-
     #endregion
     #region Status Window Helper Methods
 

--- a/ArgentiRotations/Ranged/Machinist/MachinistStatusWindow.cs
+++ b/ArgentiRotations/Ranged/Machinist/MachinistStatusWindow.cs
@@ -1,5 +1,4 @@
 ﻿using ArgentiRotations.Common;
-using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Colors;
 
 namespace ArgentiRotations.Ranged;

--- a/ArgentiRotations/Tank/Dark Knight/DarkKnightStatusWindow.cs
+++ b/ArgentiRotations/Tank/Dark Knight/DarkKnightStatusWindow.cs
@@ -1,5 +1,4 @@
 ﻿using ArgentiRotations.Common;
-using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Colors;
 
 namespace ArgentiRotations.Tank;


### PR DESCRIPTION
This pull request focuses on code cleanup and logic improvements in the `ArgentiRotations` plugin. The main changes include removing unused or unnecessary `Dalamud.Bindings.ImGui` imports across several files, refining logic in the Dancer rotation, and improving code formatting for readability.

**Code cleanup:**

* Removed unused `Dalamud.Bindings.ImGui` import statements from multiple files, including `DisplayStatusHelper.cs`, `RotationDebugManager.cs`, `BardStatusWindow.cs`, `DancerStatusWindow.cs`, `MachinistStatusWindow.cs`, and `DarkKnightStatusWindow.cs`. This helps reduce dependencies and potential confusion. [[1]](diffhunk://#diff-395ddfdd1522180312ef9f7e18a84d7acc8250aa5ef86be6cff523adb8a2166fL1) [[2]](diffhunk://#diff-88a42f5541d8727079a4d80d73f3fcddc275f7cf2fdd426dfaf59bfc97dc652fL2) [[3]](diffhunk://#diff-61bb5900c5a164dd2f8366e1f7ffe05d6e06e334e7bd8fe323340e96adcd1605L3) [[4]](diffhunk://#diff-cbd999154ac33657a5645ee3a8e1c9c24633109f7c9e26446a8b881f98fc2522L3) [[5]](diffhunk://#diff-713664d80e833044b624bac70342bc01e8cf084524b56bc7a388ccb15191e456L2) [[6]](diffhunk://#diff-ed85e3b9bcd8fe9d871429210957228448dec31d849f772046dfa261cf683a1eL2)
* Removed other unused using directives from `ArgentiUtilities.cs` for a cleaner codebase.

**Logic improvements (Dancer rotation):**

* Updated the emergency ability logic in `ChurinDNC.cs` to also check for `IsDancing`, ensuring emergency actions are only triggered when appropriate.
* Refined the logic for using Starfall Dance to account for the presence of finishing moves and cooldowns, improving decision-making during combat.

**Formatting and readability:**

* Removed unnecessary blank lines and improved region separation in `ChurinDNC.cs` and `DancerStatusWindow.cs` for better code organization and readability. [[1]](diffhunk://#diff-dc95a0b08dddbd9d2675a3a5c9cccdcf181579ae5f35b14a06de1aa1b7767c5dL269) [[2]](diffhunk://#diff-dc95a0b08dddbd9d2675a3a5c9cccdcf181579ae5f35b14a06de1aa1b7767c5dL291) [[3]](diffhunk://#diff-dc95a0b08dddbd9d2675a3a5c9cccdcf181579ae5f35b14a06de1aa1b7767c5dL348) [[4]](diffhunk://#diff-cbd999154ac33657a5645ee3a8e1c9c24633109f7c9e26446a8b881f98fc2522L14) [[5]](diffhunk://#diff-cbd999154ac33657a5645ee3a8e1c9c24633109f7c9e26446a8b881f98fc2522L42) [[6]](diffhunk://#diff-cbd999154ac33657a5645ee3a8e1c9c24633109f7c9e26446a8b881f98fc2522L118) [[7]](diffhunk://#diff-cbd999154ac33657a5645ee3a8e1c9c24633109f7c9e26446a8b881f98fc2522L369-L370)

**Assembly info update:**

* Removed an unused `using` directive from `AssemblyInfo.cs` for a cleaner assembly declaration.