### PR TITLE
more dancer improvements

### DIFF
--- a/ArgentiRotations/ArgentiRotations.csproj
+++ b/ArgentiRotations/ArgentiRotations.csproj
@@ -10,7 +10,7 @@
           </PropertyGroup>
   
           <ItemGroup>
-            <PackageReference Include="RotationSolverReborn.Basic" Version= "*" />
+            <PackageReference Include="RotationSolverReborn.Basic" Version="7.3.0.30" />
             <PackageReference Update="DalamudPackager" Version="13.0.0" />
           </ItemGroup>
   


### PR DESCRIPTION
This pull request updates the Dancer rotation logic and dependency management, focusing on refining burst window detection, potion usage, and skill activation conditions for improved gameplay accuracy and maintainability.

**Dependency Update:**
* Upgraded the `RotationSolverReborn.Basic` package to version `7.3.0.30` in `ArgentiRotations.csproj` for improved stability and compatibility.

**Dancer Rotation Logic Improvements:**

_Burst Window and Status Detection:_
* Refined the logic for detecting two-minute and odd-minute burst windows in `ChurinDNC.cs`, making the checks more accurate by incorporating additional conditions such as step completion and cooldown readiness.

_Skill and Potion Usage:_
* Adjusted the order and conditions for using `StandardStepPvE` and other actions during countdown and opener phases, ensuring more optimal skill sequencing.
* Improved the logic for using `StarfallDance` and feather actions by adding checks for finishing moves, step timing, and target health, reducing unnecessary or mistimed activations. [[1]](diffhunk://#diff-dc95a0b08dddbd9d2675a3a5c9cccdcf181579ae5f35b14a06de1aa1b7767c5dL419-R426) [[2]](diffhunk://#diff-dc95a0b08dddbd9d2675a3a5c9cccdcf181579ae5f35b14a06de1aa1b7767c5dL499-L503) [[3]](diffhunk://#diff-dc95a0b08dddbd9d2675a3a5c9cccdcf181579ae5f35b14a06de1aa1b7767c5dL614-R612)

_Potion Timing:_
* Simplified and corrected potion usage logic by removing the even/odd minute distinction, now allowing potions in both burst windows and at opener. [[1]](diffhunk://#diff-dc95a0b08dddbd9d2675a3a5c9cccdcf181579ae5f35b14a06de1aa1b7767c5dL677) [[2]](diffhunk://#diff-dc95a0b08dddbd9d2675a3a5c9cccdcf181579ae5f35b14a06de1aa1b7767c5dL697-R694)…7.3.0.30